### PR TITLE
fix: syntax error when parent_dir enabled

### DIFF
--- a/catppuccin.conf
+++ b/catppuccin.conf
@@ -49,8 +49,8 @@ setw -g window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm
 setw -g window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
 
 # parent_dir/current_dir
-# setw -g window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo "#{pane_current_path}" | rev | cut -d'/' -f-2 | rev) "
-# setw -g window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo "#{pane_current_path}" | rev | cut -d'/' -f-2 | rev) "
+# setw -g window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+# setw -g window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
 
 # --------=== Modes
 setw -g clock-mode-colour "${thm_blue}"


### PR DESCRIPTION
Hi,
I was getting a syntax error in tmux if I uncommented "parent_dir/current_dir" window status format. Seems like it was caused by double quotes in echo command which closed the one that format string was enclosed in. 
Fixed it by replacing `"` with `'` in echo command.

If I missed something and this is not a bug then I am sorry and you can disregard this PR.