### PR TITLE
feat(conf): add all catppuccin themes, split config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@
   <img src="https://raw.githubusercontent.com/catppuccin/tmux/main/assets/ss.png"/>
 </p>
 
+## Themes
+
+* 🌻 [Latte](./catppuccin-latte.conf)
+* 🪴 [Frappé](./catppuccin-frappe.conf)
+* 🌺 [Macchiato](./catppuccin-macchiato.conf)
+* 🌿 [Mocha](./catppuccin-mocha.conf)
+
 ## Usage
 
-1. Copy the contents of `catppuccin.conf` into your Tmux config (usually stored at `~/.tmux.conf`)
+1. Copy your desired theme's configuration contents into your Tmux config (usually stored at `~/.tmux.conf`)
 2. Reload Tmux by either restarting the session or reloading it with `tmux source-file ~/.tmux.conf`
 
 ## 💝 Thanks to

--- a/catppuccin-frappe.conf
+++ b/catppuccin-frappe.conf
@@ -1,20 +1,20 @@
 # NOTE: you can use vars with $<var> and ${<var>} as long as the str is double quoted: ""
 # WARNING: hex colors can't contain capital letters
 
-# --> Catppuccin
-thm_bg="#1e1e28"
-thm_fg="#dadae8"
-thm_cyan="#c2e7f0"
-thm_black="#15121c"
-thm_gray="#332e41"
-thm_magenta="#c6aae8"
-thm_pink="#e5b4e2"
-thm_red="#e38c8f"
-thm_green="#b1e3ad"
-thm_yellow="#ebddaa"
-thm_blue="#a4b9ef"
-thm_orange="#f9c096"
-thm_black4="#575268"
+# --> Catppuccin (Frappe)
+thm_bg="#232634"
+thm_fg="#c6d0f5"
+thm_cyan="#99d1db"
+thm_black="#292c3c"
+thm_gray="#51576d"
+thm_magenta="#ca9ee6"
+thm_pink="#f4b8e4"
+thm_red="#e78284"
+thm_green="#a6d189"
+thm_yellow="#e5c890"
+thm_blue="#8caaee"
+thm_orange="#ef9f76"
+thm_black4="#626880"
 
 # ----------------------------=== Theme ===--------------------------
 

--- a/catppuccin-latte.conf
+++ b/catppuccin-latte.conf
@@ -1,0 +1,57 @@
+# NOTE: you can use vars with $<var> and ${<var>} as long as the str is double quoted: ""
+# WARNING: hex colors can't contain capital letters
+
+# --> Catppuccin (Latte)
+thm_bg="#dce0e8"
+thm_fg="#4c4f69"
+thm_cyan="#179299"
+thm_black="#e6e9ef"
+thm_gray="#bcc0cc"
+thm_magenta="#ea76cb"
+thm_pink="#8839ef"
+thm_red="#d20f39"
+thm_green="#40a02b"
+thm_yellow="#df8e1d"
+thm_blue="#1e66f5"
+thm_orange="#fe640b"
+thm_black4="#acb0be"
+
+# ----------------------------=== Theme ===--------------------------
+
+# status
+set -g status-position top
+set -g status "on"
+set -g status-bg "${thm_bg}"
+set -g status-justify "left"
+set -g status-left-length "100"
+set -g status-right-length "100"
+
+# messages
+set -g message-style fg="${thm_cyan}",bg="${thm_gray}",align="centre"
+set -g message-command-style fg="${thm_cyan}",bg="${thm_gray}",align="centre"
+
+# panes
+set -g pane-border-style fg="${thm_gray}"
+set -g pane-active-border-style fg="${thm_blue}"
+
+# windows
+setw -g window-status-activity-style fg="${thm_fg}",bg="${thm_bg}",none
+setw -g window-status-separator ""
+setw -g window-status-style fg="${thm_fg}",bg="${thm_bg}",none
+
+# --------=== Statusline
+
+set -g status-left ""
+set -g status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
+
+# current_dir
+setw -g window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
+setw -g window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+
+# parent_dir/current_dir
+# setw -g window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+# setw -g window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+
+# --------=== Modes
+setw -g clock-mode-colour "${thm_blue}"
+setw -g mode-style "fg=${thm_pink} bg=${thm_black4} bold"

--- a/catppuccin-macchiato.conf
+++ b/catppuccin-macchiato.conf
@@ -1,0 +1,57 @@
+# NOTE: you can use vars with $<var> and ${<var>} as long as the str is double quoted: ""
+# WARNING: hex colors can't contain capital letters
+
+# --> Catppuccin (Macchiato)
+thm_bg="#181926"
+thm_fg="#cad3f5"
+thm_cyan="#91d7e3"
+thm_black="#1e2030"
+thm_gray="#494d64"
+thm_magenta="#c6a0f6"
+thm_pink="#f5bde6"
+thm_red="#ed8796"
+thm_green="#a6da95"
+thm_yellow="#eed49f"
+thm_blue="#8aadf4"
+thm_orange="#f5a97f"
+thm_black4="#5b6078"
+
+# ----------------------------=== Theme ===--------------------------
+
+# status
+set -g status-position top
+set -g status "on"
+set -g status-bg "${thm_bg}"
+set -g status-justify "left"
+set -g status-left-length "100"
+set -g status-right-length "100"
+
+# messages
+set -g message-style fg="${thm_cyan}",bg="${thm_gray}",align="centre"
+set -g message-command-style fg="${thm_cyan}",bg="${thm_gray}",align="centre"
+
+# panes
+set -g pane-border-style fg="${thm_gray}"
+set -g pane-active-border-style fg="${thm_blue}"
+
+# windows
+setw -g window-status-activity-style fg="${thm_fg}",bg="${thm_bg}",none
+setw -g window-status-separator ""
+setw -g window-status-style fg="${thm_fg}",bg="${thm_bg}",none
+
+# --------=== Statusline
+
+set -g status-left ""
+set -g status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
+
+# current_dir
+setw -g window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
+setw -g window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+
+# parent_dir/current_dir
+# setw -g window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+# setw -g window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+
+# --------=== Modes
+setw -g clock-mode-colour "${thm_blue}"
+setw -g mode-style "fg=${thm_pink} bg=${thm_black4} bold"

--- a/catppuccin-mocha.conf
+++ b/catppuccin-mocha.conf
@@ -1,0 +1,57 @@
+# NOTE: you can use vars with $<var> and ${<var>} as long as the str is double quoted: ""
+# WARNING: hex colors can't contain capital letters
+
+# --> Catppuccin (Mocha)
+thm_bg="#11111b"
+thm_fg="#cdd6f4"
+thm_cyan="#89dceb"
+thm_black="#181825"
+thm_gray="#45475a"
+thm_magenta="#cba6f7"
+thm_pink="#f5c2e7"
+thm_red="#f38ba8"
+thm_green="#a6e3a1"
+thm_yellow="#f9e2af"
+thm_blue="#89b4fa"
+thm_orange="#fab387"
+thm_black4="#585b70"
+
+# ----------------------------=== Theme ===--------------------------
+
+# status
+set -g status-position top
+set -g status "on"
+set -g status-bg "${thm_bg}"
+set -g status-justify "left"
+set -g status-left-length "100"
+set -g status-right-length "100"
+
+# messages
+set -g message-style fg="${thm_cyan}",bg="${thm_gray}",align="centre"
+set -g message-command-style fg="${thm_cyan}",bg="${thm_gray}",align="centre"
+
+# panes
+set -g pane-border-style fg="${thm_gray}"
+set -g pane-active-border-style fg="${thm_blue}"
+
+# windows
+setw -g window-status-activity-style fg="${thm_fg}",bg="${thm_bg}",none
+setw -g window-status-separator ""
+setw -g window-status-style fg="${thm_fg}",bg="${thm_bg}",none
+
+# --------=== Statusline
+
+set -g status-left ""
+set -g status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
+
+# current_dir
+setw -g window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
+setw -g window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+
+# parent_dir/current_dir
+# setw -g window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+# setw -g window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+
+# --------=== Modes
+setw -g clock-mode-colour "${thm_blue}"
+setw -g mode-style "fg=${thm_pink} bg=${thm_black4} bold"


### PR DESCRIPTION
## Description

* add all catppuccin themes to separate config files
* update readme to include word on choosing out your desired theme

## Resolves

- [#10](https://github.com/catppuccin/tmux/issues/10)

## Visual Reference

The following screenshots display different tmux modes/states (from top left, in clockwise rotation: prefix input, copy mode, clock, command mode):

**Latte**
![latte](https://user-images.githubusercontent.com/11083531/177011823-3676309e-dc66-48ab-bbe3-2f575044a621.png)

**Frappe**
![frappe](https://user-images.githubusercontent.com/11083531/177011831-38075d3c-4267-4aec-bd8b-bb29c81bcdc5.png)

**Macchiato**
![macchiato](https://user-images.githubusercontent.com/11083531/177011835-2da4aade-37ce-4385-9074-268c2eb302c6.png)

**Mocha**
![mocha](https://user-images.githubusercontent.com/11083531/177011844-69157181-3c2a-475b-ad4f-bc836c4bcea9.png)
