### PR TITLE
feat(window_tabs_enabled): Adding support for window tabs rather than directory tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Let's not store the selected theme in version control. This file is used to
+# source theme variables locally in the main function rather than polluting the
+# global variable namespace.
+catppuccin-selected-theme.tmuxtheme

--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ set -g @catppuccin_flavour 'latte' # or frappe, macchiato, mocha
 1. Copy your desired theme's configuration contents into your Tmux config (usually stored at `~/.tmux.conf`)
 2. Reload Tmux by either restarting the session or reloading it with `tmux source-file ~/.tmux.conf`
 
+#### Configuration options
+
+All flavours support certain levels of customization that match our [Catppuccin
+Style Guide][style-guide]. To add these customizations, add any of the following
+options to your Tmux configuration.
+
+##### Enable window tabs
+
+By default, the theme places the `window-status` in the `status-right`. With
+`@catppuccin_window_tabs_enabled` set to `on`, the theme will place the
+directory within the `status-right` and move the window names to the
+`window-status` format variables.
+
+```sh
+set -g @catppuccin_window_tabs_enabled on # or off to disable window_tabs
+```
+
+[style-guide]: https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md
+
 ## 💝 Thanks to
 
 - [Pocco81](https://github.com/catppuccin)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ set -g @catppuccin_flavour 'latte' # or frappe, macchiato, mocha
 
 - [Pocco81](https://github.com/catppuccin)
 - [vinnyA3](https://github.com/vinnyA3)
+- [rogeruiz](https://github.com/rogeruiz)
 
 &nbsp;
 

--- a/catppuccin-frappe.tmuxtheme
+++ b/catppuccin-frappe.tmuxtheme
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # NOTE: you can use vars with $<var> and ${<var>} as long as the str is double quoted: ""
 # WARNING: hex colors can't contain capital letters
 
@@ -17,55 +15,3 @@ thm_yellow="#e5c890"
 thm_blue="#8caaee"
 thm_orange="#ef9f76"
 thm_black4="#626880"
-
-# ----------------------------=== Theme ===--------------------------
-
-# utils
-set() {
-	local option=$1
-	local value=$2
-	tmux set-option -gq "$option" "$value"
-}
-
-setw() {
-	local option=$1
-	local value=$2
-	tmux set-window-option -gq "$option" "$value"
-}
-
-# status
-set status "on"
-set status-bg "${thm_bg}"
-set status-justify "left"
-set status-left-length "100"
-set status-right-length "100"
-
-# messages
-set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-
-# panes
-set pane-border-style "fg=${thm_gray}"
-set pane-active-border-style "fg=${thm_blue}"
-
-# windows
-setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
-setw window-status-separator ""
-setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
-
-# --------=== Statusline
-
-set status-left ""
-set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
-
-# current_dir
-setw window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
-setw window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-
-# parent_dir/current_dir
-# setw window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-# setw window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-
-# --------=== Modes
-setw clock-mode-colour "${thm_blue}"
-setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"

--- a/catppuccin-latte.tmuxtheme
+++ b/catppuccin-latte.tmuxtheme
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # NOTE: you can use vars with $<var> and ${<var>} as long as the str is double quoted: ""
 # WARNING: hex colors can't contain capital letters
 
@@ -17,55 +15,3 @@ thm_yellow="#df8e1d"
 thm_blue="#1e66f5"
 thm_orange="#fe640b"
 thm_black4="#acb0be"
-
-# ----------------------------=== Theme ===--------------------------
-
-# utils
-set() {
-	local option=$1
-	local value=$2
-	tmux set-option -gq "$option" "$value"
-}
-
-setw() {
-	local option=$1
-	local value=$2
-	tmux set-window-option -gq "$option" "$value"
-}
-
-# status
-set status "on"
-set status-bg "${thm_bg}"
-set status-justify "left"
-set status-left-length "100"
-set status-right-length "100"
-
-# messages
-set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-
-# panes
-set pane-border-style "fg=${thm_gray}"
-set pane-active-border-style "fg=${thm_blue}"
-
-# windows
-setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
-setw window-status-separator ""
-setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
-
-# --------=== Statusline
-
-set status-left ""
-set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
-
-# current_dir
-setw window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
-setw window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-
-# parent_dir/current_dir
-# setw window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-# setw window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-
-# --------=== Modes
-setw clock-mode-colour "${thm_blue}"
-setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"

--- a/catppuccin-macchiato.tmuxtheme
+++ b/catppuccin-macchiato.tmuxtheme
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # NOTE: you can use vars with $<var> and ${<var>} as long as the str is double quoted: ""
 # WARNING: hex colors can't contain capital letters
 
@@ -17,55 +15,3 @@ thm_yellow="#eed49f"
 thm_blue="#8aadf4"
 thm_orange="#f5a97f"
 thm_black4="#5b6078"
-
-# ----------------------------=== Theme ===--------------------------
-
-# utils
-set() {
-	local option=$1
-	local value=$2
-	tmux set-option -gq "$option" "$value"
-}
-
-setw() {
-	local option=$1
-	local value=$2
-	tmux set-window-option -gq "$option" "$value"
-}
-
-# status
-set status "on"
-set status-bg "${thm_bg}"
-set status-justify "left"
-set status-left-length "100"
-set status-right-length "100"
-
-# messages
-set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-
-# panes
-set pane-border-style "fg=${thm_gray}"
-set pane-active-border-style "fg=${thm_blue}"
-
-# windows
-setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
-setw window-status-separator ""
-setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
-
-# --------=== Statusline
-
-set status-left ""
-set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
-
-# current_dir
-setw window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
-setw window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-
-# parent_dir/current_dir
-# setw window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-# setw window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-
-# --------=== Modes
-setw clock-mode-colour "${thm_blue}"
-setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"

--- a/catppuccin-mocha.tmuxtheme
+++ b/catppuccin-mocha.tmuxtheme
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # NOTE: you can use vars with $<var> and ${<var>} as long as the str is double quoted: ""
 # WARNING: hex colors can't contain capital letters
 
@@ -17,64 +15,3 @@ thm_yellow="#f9e2af"
 thm_blue="#89b4fa"
 thm_orange="#fab387"
 thm_black4="#585b70"
-
-# ----------------------------=== Theme ===--------------------------
-
-# utils
-set() {
-	local option=$1
-	local value=$2
-	tmux set-option -gq "$option" "$value"
-}
-
-setw() {
-	local option=$1
-	local value=$2
-	tmux set-window-option -gq "$option" "$value"
-}
-
-# status
-set status "on"
-set status-bg "${thm_bg}"
-set status-justify "left"
-set status-left-length "100"
-set status-right-length "100"
-
-# messages
-set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-
-# panes
-set pane-border-style "fg=${thm_gray}"
-set pane-active-border-style "fg=${thm_blue}"
-
-# windows
-setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
-setw window-status-separator ""
-setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
-
-# TODO: continue implementing this later today...
-wt_enabled=$(tmux show -gqv @catppuccin_window_tabs_enabled)
-
-status_left=""
-if [[ "${wt_enabled}" == "on" ]]
-then
-  status_left="window_tabs_enabled"
-fi
-
-# --------=== Statusline
-
-set status-left "#[fg=$thm_red,bg=$thm_bg,nobold,nounderscore,noitalics]$status_left#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics]"
-set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
-
-# current_dir
-setw window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
-setw window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-
-# parent_dir/current_dir
-# setw window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-# setw window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-
-# --------=== Modes
-setw clock-mode-colour "${thm_blue}"
-setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"

--- a/catppuccin-mocha.tmuxtheme
+++ b/catppuccin-mocha.tmuxtheme
@@ -53,9 +53,18 @@ setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
 setw window-status-separator ""
 setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
 
+# TODO: continue implementing this later today...
+wt_enabled=$(tmux show -gqv @catppuccin_window_tabs_enabled)
+
+status_left=""
+if [[ "${wt_enabled}" == "on" ]]
+then
+  status_left="window_tabs_enabled"
+fi
+
 # --------=== Statusline
 
-set status-left ""
+set status-left "#[fg=$thm_red,bg=$thm_bg,nobold,nounderscore,noitalics]$status_left#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics]"
 set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
 
 # current_dir

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -28,9 +28,7 @@ main() {
   }
 
   local theme
-  local window_tabs_enabled
   theme="$(get-tmux-option "@catppuccin_flavour" "mocha")"
-  window_tabs_enabled="$(get-tmux-option "@catppuccin_window_tabs_enabled" "off")"
 
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
@@ -62,7 +60,12 @@ main() {
 
   # --------=== Statusline
 
+  # NOTE: Checking for the value of @catppuccin_window_tabs_enabled
+  wt_enabled="$(get-tmux-option "@catppuccin_window_tabs_enabled" "off")"
+  readonly wt_enabled
+
   # These variables are the defaults so that the setw and set calls are easier to parse.
+  readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #{?client_prefix,#[fg=$thm_red]"
   readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
   readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
 
@@ -75,6 +78,15 @@ main() {
   # Window status by default shows the current directory basename.
   local window_status_format="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
   local window_status_current_format="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+
+  # NOTE: With the @catppuccin_window_tabs_enabled set to on, we're going to
+  # update the right_column1 and the window_status_* variables.
+  if [[ "${wt_enabled}" == "on" ]]
+  then
+    right_column1=$show_directory
+    window_status_format="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+    window_status_current_format="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  fi
 
   set status-left ""
 

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -2,8 +2,6 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 main() {
-  # TODO: This function works great in here, but I'd like also like for it to set
-  # the option to the default if it's not set too. I'll get to it soon.
   get-tmux-option() {
     local option value default
     option="$1"
@@ -13,8 +11,6 @@ main() {
     if [ -n "$value" ]; then
       echo "$value"
     else
-      # README: Set the default option if it's not set originally.
-      tmux set-option -gq "${option}" "${default}"
       echo "$default"
     fi
   }

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -62,65 +62,31 @@ main() {
 
   # --------=== Statusline
 
+  # These variables are the defaults so that the setw and set calls are easier to parse.
+  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
+  readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
+
+  # Right column 1 by default shows the Window name.
+  local right_column1=$show_window
+
+  # Right column 2 by default shows the current Session name.
+  local right_column2=$show_session
+
+  # Window status by default shows the current directory basename.
+  local window_status_format="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
+  local window_status_current_format="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+
   set status-left ""
-  set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
 
-  # current_dir
-  setw window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
-  setw window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+  set status-right "${right_column1},${right_column2}"
 
-  # parent_dir/current_dir
-  # setw window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-  # setw window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+  setw window-status-format "${window_status_format}"
+  setw window-status-current-format "${window_status_current_format}"
 
   # --------=== Modes
+  #
   setw clock-mode-colour "${thm_blue}"
   setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"
-
-  # set status "on"
-  # set status-bg "${thm_bg}"
-  # set status-justify "left"
-  # set status-left-length "100"
-  # set status-right-length "100"
-  #
-  # # messages
-  # set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-  # set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-  #
-  # # panes
-  # set pane-border-style "fg=${thm_gray}"
-  # set pane-active-border-style "fg=${thm_blue}"
-  #
-  # # windows
-  # setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
-  # setw window-status-separator ""
-  # setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
-  #
-  # # --------=== Statusline
-  #
-  # # TODO: continue implementing this later today...
-  # wt_enabled=$(tmux show -gqv @catppuccin_window_tabs_enabled)
-  #
-  # status_left=""
-  # if [[ "${wt_enabled}" == "on" ]]
-  # then
-  #   status_left="window_tabs_enabled"
-  # fi
-  #
-  # set status-left "#[fg=$thm_red,bg=$thm_bg,nobold,nounderscore,noitalics]$status_left#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics]"
-  # set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg]  #[fg=$thm_fg,bg=$thm_gray] #S "
-  #
-  # # current_dir
-  # setw window-status-format "#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
-  # setw window-status-current-format "#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
-  #
-  # # parent_dir/current_dir
-  # # setw window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-  # # setw window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
-  #
-  # # --------=== Modes
-  # setw clock-mode-colour "${thm_blue}"
-  # setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"
 }
 
 main "$@"

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -16,7 +16,9 @@ get-tmux-option() {
 
 main() {
   local theme
+  local window_tabs_enabled
   theme="$(get-tmux-option "@catppuccin_flavour" "mocha")"
+  window_tabs_enabled="$(get-tmux-option "@catppuccin_window_tabs_enabled" "false")"
   tmux run -b "$CURRENT_DIR/catppuccin-${theme}.tmuxtheme"
 }
 

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -10,6 +10,8 @@ get-tmux-option() {
   if [ -n "$value" ]; then
     echo "$value"
   else
+    # README: Set the default option if it's not set originally.
+    tmux set-option -gq "${option}" "${default}"
     echo "$default"
   fi
 }

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -68,6 +68,10 @@ main() {
   readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #{?client_prefix,#[fg=$thm_red]"
   readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
   readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
+  readonly show_directory_in_window_status="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
+  readonly show_directory_in_window_status_current="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+  readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
 
   # Right column 1 by default shows the Window name.
   local right_column1=$show_window
@@ -76,16 +80,16 @@ main() {
   local right_column2=$show_session
 
   # Window status by default shows the current directory basename.
-  local window_status_format="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
-  local window_status_current_format="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+  local window_status_format=$show_directory_in_window_status
+  local window_status_current_format=$show_directory_in_window_status_current
 
   # NOTE: With the @catppuccin_window_tabs_enabled set to on, we're going to
   # update the right_column1 and the window_status_* variables.
   if [[ "${wt_enabled}" == "on" ]]
   then
     right_column1=$show_directory
-    window_status_format="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
-    window_status_current_format="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+    window_status_format=$show_window_in_window_status
+    window_status_current_format=$show_window_in_window_status_current
   fi
 
   set status-left ""

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PLUGIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 main() {
   get-tmux-option() {
@@ -33,10 +33,10 @@ main() {
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
   sed -E 's/^(.+=)/local \1/' \
-      > catppuccin-selected-theme.tmuxtheme \
-      < "${CURRENT_DIR}/catppuccin-${theme}.tmuxtheme"
+      > "${PLUGIN_DIR}/catppuccin-selected-theme.tmuxtheme" \
+      < "${PLUGIN_DIR}/catppuccin-${theme}.tmuxtheme"
 
-  source catppuccin-selected-theme.tmuxtheme
+  source "${PLUGIN_DIR}/catppuccin-selected-theme.tmuxtheme"
 
   # status
   set status "on"

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -1,27 +1,130 @@
 #!/usr/bin/env bash
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-get-tmux-option() {
-  local option value default
-  option="$1"
-  default="$2"
-  value="$(tmux show-option -gqv "$option")"
-
-  if [ -n "$value" ]; then
-    echo "$value"
-  else
-    # README: Set the default option if it's not set originally.
-    tmux set-option -gq "${option}" "${default}"
-    echo "$default"
-  fi
-}
-
 main() {
+  # TODO: This function works great in here, but I'd like also like for it to set
+  # the option to the default if it's not set too. I'll get to it soon.
+  get-tmux-option() {
+    local option value default
+    option="$1"
+    default="$2"
+    value="$(tmux show-option -gqv "$option")"
+
+    if [ -n "$value" ]; then
+      echo "$value"
+    else
+      # README: Set the default option if it's not set originally.
+      tmux set-option -gq "${option}" "${default}"
+      echo "$default"
+    fi
+  }
+
+  set() {
+    local option=$1
+    local value=$2
+    tmux set-option -gq "$option" "$value"
+  }
+
+  setw() {
+    local option=$1
+    local value=$2
+    tmux set-window-option -gq "$option" "$value"
+  }
+
   local theme
   local window_tabs_enabled
   theme="$(get-tmux-option "@catppuccin_flavour" "mocha")"
-  window_tabs_enabled="$(get-tmux-option "@catppuccin_window_tabs_enabled" "false")"
-  tmux run -b "$CURRENT_DIR/catppuccin-${theme}.tmuxtheme"
+  window_tabs_enabled="$(get-tmux-option "@catppuccin_window_tabs_enabled" "off")"
+
+  # NOTE: Pulling in the selected theme by the theme that's being set as local
+  # variables.
+  sed -E 's/^(.+=)/local \1/' \
+      > catppuccin-selected-theme.tmuxtheme \
+      < "${CURRENT_DIR}/catppuccin-${theme}.tmuxtheme"
+
+  source catppuccin-selected-theme.tmuxtheme
+
+  # status
+  set status "on"
+  set status-bg "${thm_bg}"
+  set status-justify "left"
+  set status-left-length "100"
+  set status-right-length "100"
+
+  # messages
+  set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
+  set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
+
+  # panes
+  set pane-border-style "fg=${thm_gray}"
+  set pane-active-border-style "fg=${thm_blue}"
+
+  # windows
+  setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
+  setw window-status-separator ""
+  setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
+
+  # --------=== Statusline
+
+  set status-left ""
+  set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
+
+  # current_dir
+  setw window-status-format "#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
+  setw window-status-current-format "#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+
+  # parent_dir/current_dir
+  # setw window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+  # setw window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+
+  # --------=== Modes
+  setw clock-mode-colour "${thm_blue}"
+  setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"
+
+  # set status "on"
+  # set status-bg "${thm_bg}"
+  # set status-justify "left"
+  # set status-left-length "100"
+  # set status-right-length "100"
+  #
+  # # messages
+  # set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
+  # set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
+  #
+  # # panes
+  # set pane-border-style "fg=${thm_gray}"
+  # set pane-active-border-style "fg=${thm_blue}"
+  #
+  # # windows
+  # setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
+  # setw window-status-separator ""
+  # setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
+  #
+  # # --------=== Statusline
+  #
+  # # TODO: continue implementing this later today...
+  # wt_enabled=$(tmux show -gqv @catppuccin_window_tabs_enabled)
+  #
+  # status_left=""
+  # if [[ "${wt_enabled}" == "on" ]]
+  # then
+  #   status_left="window_tabs_enabled"
+  # fi
+  #
+  # set status-left "#[fg=$thm_red,bg=$thm_bg,nobold,nounderscore,noitalics]$status_left#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics]"
+  # set status-right "#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) #{?client_prefix,#[fg=$thm_red],#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg]  #[fg=$thm_fg,bg=$thm_gray] #S "
+  #
+  # # current_dir
+  # setw window-status-format "#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  # setw window-status-current-format "#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  #
+  # # parent_dir/current_dir
+  # # setw window-status-format "#[fg=colour232,bg=colour111] #I #[fg=colour222,bg=colour235] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+  # # setw window-status-current-format "#[fg=colour232,bg=colour208] #I #[fg=colour255,bg=colour237] #(echo '#{pane_current_path}' | rev | cut -d'/' -f-2 | rev) "
+  #
+  # # --------=== Modes
+  # setw clock-mode-colour "${thm_blue}"
+  # setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"
 }
 
 main "$@"


### PR DESCRIPTION
This option, for now, defaults to `false`. This is just so it keeps the
initial design intention for the original design of the plugin. I may
flip it or change the name of the variable in future commits. This patch
is addressing catppuccin/tmux#16.

Alright, this closes #16 when it's merged into the default branch. If anyone would like to test this out locally, you _should_ be able to set a new remote to my GH fork and then change branches to `add-option-to-display-folders`.

The commands to do that in your local Git repository should be:

```sh
cd ~/.tmux/plugins/tmux
git remote add rogeruiz https://github.com/rogeruiz/tmux.git
git fetch --all
git checkout add-option-to-display-folders
```

Afterwards, you can follow the documentation in the `README.md` to turn on the feature. Remember to source your Tmux configuration file when you update it if you're in a session.

When you're done, you can remove the remote and go back to the default branch with the following:

```sh
cd ~/.tmux/plugins/tmux
git remote rm rogeruiz
git checkout main
```
