### PR TITLE
feat(window_status_enabled,window_icons_enabled) Adding window status indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ the window status as defined by the `#F` variable in Tmux using the known
 characters such as `Z`, `*`, and `-`. If you would like Nerd Font supported
 icons for the default Tmux window status, you can enable them like so.
 
-```sh
-set -g @catppuccin_window_icons_enabled on
+```bash
+set -g @catppuccin_window_icons_enabled on # or off to disable window icons
 ```
+
 <details>
 <summary><a
 href="https://github.com/tmux/tmux/blob/master/tmux.1#L5632-L5641">Read more

--- a/README.md
+++ b/README.md
@@ -65,6 +65,36 @@ set -g @catppuccin_window_tabs_enabled on # or off to disable window_tabs
 
 [style-guide]: https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md
 
+##### Enable window status
+
+By default, the theme includes window status as plain text. This will display
+the window status as defined by the `#F` variable in Tmux using the known
+characters such as `Z`, `*`, and `-`. If you would like Nerd Font supported
+icons for the default Tmux window status, you can enable them like so.
+
+```sh
+set -g @catppuccin_window_icons_enabled on
+```
+<details>
+<summary><a
+href="https://github.com/tmux/tmux/blob/master/tmux.1#L5632-L5641">Read more
+about the flags in the Tmux source code directly</a>, or by clicking on the
+non-highlighted text here.</summary>
+
+```text
+Symbol    Meaning
+*         Denotes the current window.
+-         Marks the last window (previously selected).
+#         Window activity is monitored and activity has been detected.
+!         Window bells are monitored and a bell has occurred in the window.
+~         The window has been silent for the monitor-silence interval.
+M         The window contains the marked pane.
+Z         The window's active pane is zoomed.
+```
+
+</details>
+
+
 ## 💝 Thanks to
 
 - [Pocco81](https://github.com/catppuccin)

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -63,15 +63,48 @@ main() {
   # NOTE: Checking for the value of @catppuccin_window_tabs_enabled
   wt_enabled="$(get-tmux-option "@catppuccin_window_tabs_enabled" "off")"
   readonly wt_enabled
+  
+  wi_enabled="$(get-tmux-option "@catppuccin_window_icons_enabled" "off")"
+  readonly wi_enabled
 
   # These variables are the defaults so that the setw and set calls are easier to parse.
+
+  # Default Nerd Font zoom/mark icons
+  readonly icon_window_zoom_off="  "
+  readonly icon_window_zoom_on=" "
+  readonly icon_window_zoom_mark=""
+
+  custom_icon_window="$(get-tmux-option "@catppuccin_icon_window" ${icon_window_zoom_off})"
+  readonly custom_icon_window
+
+  custom_icon_window_zoom="$(get-tmux-option "@catppuccin_icon_window_zoom" ${icon_window_zoom_on})"
+  readonly custom_icon_window_zoom
+
+  custom_icon_window_mark="$(get-tmux-option "@catppuccin_icon_window_mark" ${icon_window_zoom_mark})"
+  readonly custom_icon_window_mark
+
+  # Default zoom/mark icons
+  local show_window_zoom_off=""
+  local show_window_zoom_on="*Z"
+  local show_window_zoom_mark="*M"
+  
+  if [[ "${wi_enabled}" == "on" ]]
+  then
+    show_window_zoom_off=${custom_icon_window}
+    show_window_zoom_on=${custom_icon_window_zoom}
+    show_window_zoom_mark=${custom_icon_window_mark}
+  fi
+
+  # Set the window zoom variable
+  readonly show_window_zoom_status="#(if [[ \"#F\" == \"*\" ]]; then echo ${show_window_zoom_off}; elif [[ \"#F\" == \"*Z\" ]]; then echo ${show_window_zoom_on}; elif [[ \"#F\" == \"*M\" ]]; then echo ${show_window_zoom_mark}; fi)"
+
   readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #{?client_prefix,#[fg=$thm_red]"
-  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
+  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]${show_window_zoom_status} #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
   readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
   readonly show_directory_in_window_status="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
   readonly show_directory_in_window_status_current="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-  readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
-  readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]${show_window_zoom_status}#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]${show_window_zoom_status}#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
 
   # Right column 1 by default shows the Window name.
   local right_column1=$show_window
@@ -82,6 +115,7 @@ main() {
   # Window status by default shows the current directory basename.
   local window_status_format=$show_directory_in_window_status
   local window_status_current_format=$show_directory_in_window_status_current
+
 
   # NOTE: With the @catppuccin_window_tabs_enabled set to on, we're going to
   # update the right_column1 and the window_status_* variables.

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -63,11 +63,15 @@ main() {
   # NOTE: Checking for the value of @catppuccin_window_tabs_enabled
   wt_enabled="$(get-tmux-option "@catppuccin_window_tabs_enabled" "off")"
   readonly wt_enabled
-  
+
+  # NOTE: Checking for the value of @catppuccin_window_tabs_enabled
   wi_enabled="$(get-tmux-option "@catppuccin_window_icons_enabled" "off")"
   readonly wi_enabled
 
-  # These variables are the defaults so that the setw and set calls are easier to parse.
+  # README: Any variables marked `readonly` are the defaults so that it is
+  # easier to understand what is a default value. Some variables are marked
+  # `local` and that's because they will be used in place for the `setw` and
+  # `set` commands to make it easier to parse what is happening.
 
   # Default Nerd Font zoom/mark icons
   readonly icon_window_zoom_off="  "
@@ -88,6 +92,9 @@ main() {
   local show_window_zoom_on="*Z"
   local show_window_zoom_mark="*M"
   
+  # NOTE: With the @catppuccin_window_icons_enabled set to on, we're going to
+  # update the show_window_status with a custom command to replace all the
+  # things that it would normally use according to the Tmux source.
   if [[ "${wi_enabled}" == "on" ]]
   then
     show_window_zoom_off=${custom_icon_window}

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -74,44 +74,55 @@ main() {
   # `set` commands to make it easier to parse what is happening.
 
   # Default Nerd Font zoom/mark icons
-  readonly icon_window_zoom_off="  "
-  readonly icon_window_zoom_on=" "
-  readonly icon_window_zoom_mark=""
+  readonly icon_window_current="  "
+  readonly icon_window_last="  "
+  readonly icon_window_activity="  "
+  readonly icon_window_bell=" "
+  readonly icon_window_silent=" "
+  readonly icon_window_zoom="  "
+  readonly icon_window_mark=" "
 
-  custom_icon_window="$(get-tmux-option "@catppuccin_icon_window" ${icon_window_zoom_off})"
-  readonly custom_icon_window
+  # README: The following variables are set to the defaults above but can be
+  # overwritten by the user.
+  custom_icon_window_last="$(get-tmux-option "@catppuccin_icon_window_last" "${icon_window_last}")"
+  readonly custom_icon_window_last
 
-  custom_icon_window_zoom="$(get-tmux-option "@catppuccin_icon_window_zoom" ${icon_window_zoom_on})"
+  custom_icon_window_current="$(get-tmux-option "@catppuccin_icon_window_current" "${icon_window_current}")"
+  readonly custom_icon_window_current
+
+  custom_icon_window_zoom="$(get-tmux-option "@catppuccin_icon_window_zoom" "${icon_window_zoom}")"
   readonly custom_icon_window_zoom
 
-  custom_icon_window_mark="$(get-tmux-option "@catppuccin_icon_window_mark" ${icon_window_zoom_mark})"
+  custom_icon_window_mark="$(get-tmux-option "@catppuccin_icon_window_mark" "${icon_window_mark}")"
   readonly custom_icon_window_mark
 
-  # Default zoom/mark icons
-  local show_window_zoom_off=""
-  local show_window_zoom_on="*Z"
-  local show_window_zoom_mark="*M"
-  
+  custom_icon_window_silent="$(get-tmux-option "@catppuccin_icon_window_silent" "${icon_window_silent}")"
+  readonly custom_icon_window_silent
+
+  custom_icon_window_activity="$(get-tmux-option "@catppuccin_icon_window_activity" "${icon_window_activity}")"
+  readonly custom_icon_window_activity
+
+  custom_icon_window_bell="$(get-tmux-option "@catppuccin_icon_window_bell" "${icon_window_bell}")"
+  readonly custom_icon_window_bell
+
+  # Set default the window status variable
+  local show_window_status="#F "
+
   # NOTE: With the @catppuccin_window_icons_enabled set to on, we're going to
   # update the show_window_status with a custom command to replace all the
   # things that it would normally use according to the Tmux source.
   if [[ "${wi_enabled}" == "on" ]]
   then
-    show_window_zoom_off=${custom_icon_window}
-    show_window_zoom_on=${custom_icon_window_zoom}
-    show_window_zoom_mark=${custom_icon_window_mark}
+    show_window_status="#(printf '%%s\n' '#F' | sed \"s/*/${custom_icon_window_current}/\" | sed \"s/-/${custom_icon_window_last}/\" | sed \"s/#/${custom_icon_window_activity}/\" | sed \"s/#//g\"| sed \"s/~/${custom_icon_window_silent}/\" | sed \"s/!/${custom_icon_window_bell}/\" | sed \"s/M/${custom_icon_window_mark}/\" | sed \"s/Z/${custom_icon_window_zoom}/\")"
   fi
 
-  # Set the window zoom variable
-  readonly show_window_zoom_status="#(if [[ \"#F\" == \"*\" ]]; then echo ${show_window_zoom_off}; elif [[ \"#F\" == \"*Z\" ]]; then echo ${show_window_zoom_on}; elif [[ \"#F\" == \"*M\" ]]; then echo ${show_window_zoom_mark}; fi)"
-
   readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #{?client_prefix,#[fg=$thm_red]"
-  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]${show_window_zoom_status} #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
+  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]${show_window_status} #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
   readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
   readonly show_directory_in_window_status="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
   readonly show_directory_in_window_status_current="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-  readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]${show_window_zoom_status}#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
-  readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]${show_window_zoom_status}#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] ${show_window_status}#I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] ${show_window_status}#I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
 
   # Right column 1 by default shows the Window name.
   local right_column1=$show_window
@@ -122,7 +133,6 @@ main() {
   # Window status by default shows the current directory basename.
   local window_status_format=$show_directory_in_window_status
   local window_status_current_format=$show_directory_in_window_status_current
-
 
   # NOTE: With the @catppuccin_window_tabs_enabled set to on, we're going to
   # update the right_column1 and the window_status_* variables.


### PR DESCRIPTION
This closes #17. It can only be merged in though after #22 since it builds on
top of the major refactor in that branch.

Relevant commits that aren't in the #22 PR.

- [x] Initial support for window icons;
- [x] Updating the comments around what I'm doing here
- [x] Adding in the base functionality;
- [ ] Updating the documentation 
    - [ ] Update screenshots to show the default without icons
    - [ ] Update screenshots to show the default _with_ icons
