### PR TITLE
Add rounded icons in all places in the statusline

### DIFF
--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -65,13 +65,13 @@ main() {
   readonly wt_enabled
 
   # These variables are the defaults so that the setw and set calls are easier to parse.
-  readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #{?client_prefix,#[fg=$thm_red]"
-  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
-  readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
-  readonly show_directory_in_window_status="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
-  readonly show_directory_in_window_status_current="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
-  readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
-  readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path}#[fg=$thm_gray,bg=$thm_bg] #{?client_prefix,#[fg=$thm_red]"
+  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W#[fg=$thm_gray,bg=$thm_bg] #{?client_prefix,#[fg=$thm_red]"
+  readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S#[fg=$thm_gray,bg=$thm_bg]"
+  readonly show_directory_in_window_status="#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_bg,bg=$thm_blue]#I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #[fg=$thm_gray,bg=$thm_bg] "
+  readonly show_directory_in_window_status_current="#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_bg,bg=$thm_orange]#I #[fg=$thm_fg,bg=$thm_black4] #{b:pane_current_path} #[fg=$thm_black4,bg=$thm_bg] "
+  readonly show_window_in_window_status="#[fg=$thm_gray]#[bg=$thm_bg]#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_window_in_window_status_current="#[fg=$thm_gray]#[bg=$thm_bg]#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
 
   # Right column 1 by default shows the Window name.
   local right_column1=$show_window


### PR DESCRIPTION
Never understood why keep the style on the left side different from the right side if it's already using the nerd icons.

This PR will make everything rounded.

**Preview:**
![tabs_enabled](https://user-images.githubusercontent.com/33607846/210030613-e57f8660-f30b-4cbb-83b5-b6bb8bb1ebae.png)

![tabs_disabled](https://user-images.githubusercontent.com/33607846/210030137-e360fdcc-97a1-4b8b-8209-e12b44d57190.png)

It's way prettier, in my opinion.