### PR TITLE
Improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-# Let's not store the selected theme in version control. This file is used to
-# source theme variables locally in the main function rather than polluting the
-# global variable namespace.
-catppuccin-selected-theme.tmuxtheme

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -32,11 +32,8 @@ main() {
 
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
-  sed -E 's/^(.+=)/local \1/' \
-      > "${PLUGIN_DIR}/catppuccin-selected-theme.tmuxtheme" \
-      < "${PLUGIN_DIR}/catppuccin-${theme}.tmuxtheme"
-
-  source "${PLUGIN_DIR}/catppuccin-selected-theme.tmuxtheme"
+  # shellcheck source=catppuccin-frappe.tmuxtheme
+  source /dev/stdin <<<"$(sed -e "/^[^#].*=/s/^/local /" "${PLUGIN_DIR}/catppuccin-${theme}.tmuxtheme")"
 
   # status
   set status "on"


### PR DESCRIPTION
1. Don't create temporary files. It fixes an error for me when loading theme from a read-only filesystem (Nix store in my case).
2. Calling `tmux` for every variable is pretty slow. I changed it to aggregate all commands in a variable, then call it once.

Before:
```
Executed in   98.28 millis    fish           external
   usr time   53.09 millis    0.00 micros   53.09 millis
   sys time   20.00 millis  667.00 micros   19.33 millis
```

After:
```
Executed in   22.50 millis    fish           external
   usr time   14.36 millis  618.00 micros   13.74 millis
   sys time    5.53 millis  115.00 micros    5.41 millis
```

My first version printed commands in a function. Then I did `load_theme | tmux source-file -`, but looks like reading commands from stdin is pretty recent change in tmux (3.1): https://github.com/tmux/tmux/commit/5134666702ce972390f39e34bed9b60fe566263a. A second approach was `tmux source-file <(load_theme)`, but unfortunately it didn't work. Useful feature of using function for generating config lines would be that I also added command line switch, and user could `./catppuccin.tmux print >> ~/.config/tmux/tmux.conf`. But since it didn't work, it's not available.

If you don't like aggregation of commands, I can remove it, but I still want a fix for read-only filesystems.