### PR TITLE
feat(ui): make the separator configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-# Let's not store the selected theme in version control. This file is used to
-# source theme variables locally in the main function rather than polluting the
-# global variable namespace.
-catppuccin-selected-theme.tmuxtheme

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ directory within the `status-right` and move the window names to the
 set -g @catppuccin_window_tabs_enabled on # or off to disable window_tabs
 ```
 
+##### Configure separator
+
+By default, the theme will use a round separator for left and right.
+To overwrite it use `@catppuccin_left_separator` and `@catppuccin_right_separator` 
+
+```sh
+set -g @catppuccin_left_separator "█"
+set -g @catppuccin_right_separator "█"
+
+```
+
 [style-guide]: https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md
 
 ## 💝 Thanks to

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -1,42 +1,42 @@
 #!/usr/bin/env bash
-PLUGIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+get_tmux_option() {
+  local option value default
+  option="$1"
+  default="$2"
+  value="$(tmux show-option -gqv "$option")"
+
+  if [ -n "$value" ]; then
+    echo "$value"
+  else
+    echo "$default"
+  fi
+}
+
+set() {
+  local option=$1
+  local value=$2
+  tmux_commands+=(set-option -gq "$option" "$value" ";")
+}
+
+setw() {
+  local option=$1
+  local value=$2
+  tmux_commands+=(set-window-option -gq "$option" "$value" ";")
+}
 
 main() {
-  get-tmux-option() {
-    local option value default
-    option="$1"
-    default="$2"
-    value="$(tmux show-option -gqv "$option")"
-
-    if [ -n "$value" ]; then
-      echo "$value"
-    else
-      echo "$default"
-    fi
-  }
-
-  set() {
-    local option=$1
-    local value=$2
-    tmux set-option -gq "$option" "$value"
-  }
-
-  setw() {
-    local option=$1
-    local value=$2
-    tmux set-window-option -gq "$option" "$value"
-  }
-
   local theme
-  theme="$(get-tmux-option "@catppuccin_flavour" "mocha")"
+  theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
+
+  # Aggregate all commands in one array
+  local tmux_commands=()
 
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
-  sed -E 's/^(.+=)/local \1/' \
-      > "${PLUGIN_DIR}/catppuccin-selected-theme.tmuxtheme" \
-      < "${PLUGIN_DIR}/catppuccin-${theme}.tmuxtheme"
-
-  source "${PLUGIN_DIR}/catppuccin-selected-theme.tmuxtheme"
+  # shellcheck source=catppuccin-frappe.tmuxtheme
+  source /dev/stdin <<<"$(sed -e "/^[^#].*=/s/^/local /" "${PLUGIN_DIR}/catppuccin-${theme}.tmuxtheme")"
 
   # status
   set status "on"
@@ -61,16 +61,24 @@ main() {
   # --------=== Statusline
 
   # NOTE: Checking for the value of @catppuccin_window_tabs_enabled
-  wt_enabled="$(get-tmux-option "@catppuccin_window_tabs_enabled" "off")"
+  local wt_enabled
+  wt_enabled="$(get_tmux_option "@catppuccin_window_tabs_enabled" "off")"
   readonly wt_enabled
 
   # These variables are the defaults so that the setw and set calls are easier to parse.
+  local show_directory
   readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #{?client_prefix,#[fg=$thm_red]"
+  local show_window
   readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
+  local show_session
   readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
+  local show_directory_in_window_status
   readonly show_directory_in_window_status="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
+  local show_directory_in_window_status_current
   readonly show_directory_in_window_status_current="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
+  local show_window_in_window_status
   readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  local show_window_in_window_status_current
   readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
 
   # Right column 1 by default shows the Window name.
@@ -85,8 +93,7 @@ main() {
 
   # NOTE: With the @catppuccin_window_tabs_enabled set to on, we're going to
   # update the right_column1 and the window_status_* variables.
-  if [[ "${wt_enabled}" == "on" ]]
-  then
+  if [[ "${wt_enabled}" == "on" ]]; then
     right_column1=$show_directory
     window_status_format=$show_window_in_window_status
     window_status_current_format=$show_window_in_window_status_current
@@ -103,6 +110,8 @@ main() {
   #
   setw clock-mode-colour "${thm_blue}"
   setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"
+
+  tmux "${tmux_commands[@]}"
 }
 
 main "$@"

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -64,22 +64,24 @@ main() {
   local wt_enabled
   wt_enabled="$(get_tmux_option "@catppuccin_window_tabs_enabled" "off")"
   readonly wt_enabled
+  readonly right_separator="$(get-tmux-option "@catppuccin_right_separator" "")"
+  readonly left_separator="$(get-tmux-option "@catppuccin_left_separator" "")"
 
   # These variables are the defaults so that the setw and set calls are easier to parse.
   local show_directory
-  readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #{?client_prefix,#[fg=$thm_red]"
+  readonly show_directory="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]$right_separator#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics]  #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} #{?client_prefix,#[fg=$thm_red]"
   local show_window
-  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
+  readonly show_window="#[fg=$thm_pink,bg=$thm_bg,nobold,nounderscore,noitalics]$right_separator#[fg=$thm_bg,bg=$thm_pink,nobold,nounderscore,noitalics] #[fg=$thm_fg,bg=$thm_gray] #W #{?client_prefix,#[fg=$thm_red]"
   local show_session
-  readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
+  readonly show_session="#[fg=$thm_green]}#[bg=$thm_gray]$right_separator#{?client_prefix,#[bg=$thm_red],#[bg=$thm_green]}#[fg=$thm_bg] #[fg=$thm_fg,bg=$thm_gray] #S "
   local show_directory_in_window_status
   readonly show_directory_in_window_status="#[fg=$thm_bg,bg=$thm_blue] #I #[fg=$thm_fg,bg=$thm_gray] #{b:pane_current_path} "
   local show_directory_in_window_status_current
   readonly show_directory_in_window_status_current="#[fg=$thm_bg,bg=$thm_orange] #I #[fg=$thm_fg,bg=$thm_bg] #{b:pane_current_path} "
   local show_window_in_window_status
-  readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_window_in_window_status="#[fg=$thm_fg,bg=$thm_bg] #W #[fg=$thm_bg,bg=$thm_blue] #I#[fg=$thm_blue,bg=$thm_bg]$left_separator#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
   local show_window_in_window_status_current
-  readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
+  readonly show_window_in_window_status_current="#[fg=$thm_fg,bg=$thm_gray] #W #[fg=$thm_bg,bg=$thm_orange] #I#[fg=$thm_orange,bg=$thm_bg]$left_separator#[fg=$thm_fg,bg=$thm_bg,nobold,nounderscore,noitalics] "
 
   # Right column 1 by default shows the Window name.
   local right_column1=$show_window


### PR DESCRIPTION
Added a way to configure the separator. 
The default behavior is to use the rounded separator. 
Updated the documentation as well.