### PR TITLE
Add prepend and append capability to take user-space configs

### DIFF
--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -76,6 +76,14 @@ main() {
   local user
   user="$(get_tmux_option "@catppuccin_user" "off")"
   readonly user
+  
+  local prepend
+  prepend="$(get_tmux_option "@catppuccin_prepend" "")"
+  readonly prepend
+  
+  local append
+  append="$(get_tmux_option "@catppuccin_append" "")"
+  readonly append
 
   local host
   host="$(get_tmux_option "@catppuccin_host" "off")"
@@ -148,7 +156,7 @@ main() {
 
   set status-left ""
 
-  set status-right "${right_column1},${right_column2}"
+  set status-right "${prepend}${right_column1},${right_column2}${append}"
 
   setw window-status-format "${window_status_format}"
   setw window-status-current-format "${window_status_current_format}"


### PR DESCRIPTION
Solves #39  by adding an ability to prepend and append to status-right. Tested with tmux-battery specifically for my use-case.
Usage example:
```
set -g @plugin 'catppuccin/tmux'
set -g @catppuccin_flavour 'latte'

set -g @plugin 'tmux-plugins/tmux-battery'
set -g @catppuccin_prepend 'Bat: #{battery_percentage} #{battery_remain} | %a %h-%d %H:%M '
```
![tg_image_1079405351](https://github.com/catppuccin/tmux/assets/57024156/6b4f452f-1ca5-43ab-b007-e907fe507465)

Note: the order of loading of plugins matter here. You want plugins that override `status-right` to load after a theme itself.
