### PR TITLE
feat(status): allow modules in left_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
    1. [Config 1](#config-1)
    2. [Config 2](#config-2)
    3. [Config 3](#config-3)
-   
+
 ## Themes
 
 - 🌻 [Latte](./catppuccin-latte.tmuxtheme)
@@ -143,7 +143,7 @@ Values:
 
 #### Override the window default text:
 ```sh
-set -g @catppuccin_window_default_text "#{b:pane_current_path}" # use "#W" for application instead of directory 
+set -g @catppuccin_window_default_text "#{b:pane_current_path}" # use "#W" for application instead of directory
 ```
 
 ### Window current
@@ -159,7 +159,7 @@ Values:
 
 #### Override the window current text:
 ```sh
-set -g @catppuccin_window_current_text "#{b:pane_current_path}" # use "#W" for application instead of directory 
+set -g @catppuccin_window_current_text "#{b:pane_current_path}" # use "#W" for application instead of directory
 ```
 
 #### Set the current directory format
@@ -215,7 +215,12 @@ Values:
 ```sh
 set -g @catppuccin_status_modules "application session"
 ```
-Provide a list of modules and the order in which you want them to appear in the status. 
+Provide a list of modules and the order in which you want them to appear in the status.
+
+Modules can also be added to the left status:
+```sh
+set -g @catppuccin_left_status_modules "session"
+```
 
 Available modules:
 - application - display the current window running application
@@ -245,7 +250,7 @@ set -g @catppuccin_[module_name]_color "color"
 set -g @catppuccin_[module_name]_text "text"
 ```
 
-#### Removing a specific module option 
+#### Removing a specific module option
 ```sh
 set -g @catppuccin_[module_name]_[option] "null"
 ```
@@ -258,7 +263,7 @@ set -g @catppuccin_date_time_icon "null"
 ### Battery module
 
 #### Requirements
-This module depends on [tmux-battery](https://github.com/tmux-plugins/tmux-battery/tree/master). 
+This module depends on [tmux-battery](https://github.com/tmux-plugins/tmux-battery/tree/master).
 
 #### Install
 The prefered way to install tmux-battery is using [TPM](https://github.com/tmux-plugins/tpm).

--- a/README.md
+++ b/README.md
@@ -213,14 +213,10 @@ Values:
 
 #### Set the module list
 ```sh
-set -g @catppuccin_status_modules "application session"
+set -g @catppuccin_status_modules_right "application session"
+set -g @catppuccin_status_modules_left ""
 ```
 Provide a list of modules and the order in which you want them to appear in the status.
-
-Modules can also be added to the left status:
-```sh
-set -g @catppuccin_left_status_modules "session"
-```
 
 Available modules:
 - application - display the current window running application

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -312,14 +312,14 @@ main() {
   local status_connect_separator=$(get_tmux_option "@catppuccin_status_connect_separator" "yes")
   local status_fill=$(get_tmux_option "@catppuccin_status_fill" "icon")
 
-  local status_modules=$(get_tmux_option "@catppuccin_status_modules" "application session")
-  local loaded_modules=$( load_modules "$status_modules")
+  local status_modules_right=$(get_tmux_option "@catppuccin_status_modules_right" "application session")
+  local loaded_modules_right=$( load_modules "$status_modules_right")
 
-  local left_status_modules=$(get_tmux_option "@catppuccin_left_status_modules" "")
-  local left_loaded_modules=$( load_modules "$left_status_modules")
+  local status_modules_left=$(get_tmux_option "@catppuccin_status_modules_left" "")
+  local loaded_modules_left=$( load_modules "$status_modules_left")
 
-  set status-left "$left_loaded_modules"
-  set status-right "$loaded_modules"
+  set status-left "$loaded_modules_left"
+  set status-right "$loaded_modules_right"
 
   # --------=== Modes
   #

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -315,7 +315,10 @@ main() {
   local status_modules=$(get_tmux_option "@catppuccin_status_modules" "application session")
   local loaded_modules=$( load_modules "$status_modules")
 
-  set status-left ""
+  local left_status_modules=$(get_tmux_option "@catppuccin_left_status_modules" "")
+  local left_loaded_modules=$( load_modules "$left_status_modules")
+
+  set status-left "$left_loaded_modules"
   set status-right "$loaded_modules"
 
   # --------=== Modes


### PR DESCRIPTION
Added possibility of adding modules also to the left of the status line. 

Example:

```sh
set -g @catppuccin_status_modules "host"
set -g @catppuccin_left_status_modules "session"
```
<img width="1274" alt="Screenshot 2023-08-29 at 09 18 25" src="https://github.com/catppuccin/tmux/assets/16779791/f4316ce1-2bab-4ef7-8c1f-1c40612add00">
