### PR TITLE
feat(cpu): add cpu module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
    4. [Status](#status)
    5. [Customizing modules](#customizing-modules)
    6. [Battery module](#battery-module)
+   7. [CPU module](#CPU-module)
 5. [Create a custom module](#create-a-custom-module)
 6. [Configuration Examples](#configuration-examples)
    1. [Config 1](#config-1)
@@ -275,6 +276,27 @@ set -g @plugin 'tmux-plugins/tmux-battery'
 Add the battery module to the status modules list.
 ```sh
 set -g @catppuccin_status_modules_right "... battery ..."
+```
+
+### CPU module
+
+#### Requirements
+This module depends on [tmux-cpu](https://github.com/tmux-plugins/tmux-cpu/tree/master).
+
+#### Install
+The prefered way to install tmux-cpu is using [TPM](https://github.com/tmux-plugins/tpm).
+
+#### Configure
+Load tmux-cpu after you load catppuccin.
+```sh
+set -g @plugin 'catppuccin/tmux'
+...
+set -g @plugin 'tmux-plugins/tmux-cpu'
+```
+
+Add the cpu module to the status modules list.
+```sh
+set -g @catppuccin_status_modules_right "... cpu ..."
 ```
 
 ## Create a custom module

--- a/status/cpu.sh
+++ b/status/cpu.sh
@@ -1,0 +1,14 @@
+show_cpu() {
+  tmux set-option -g @cpu_low_bg_color "$thm_yellow" # background color when cpu is low
+  tmux set-option -g @cpu_medium_bg_color "$thm_orange" # background color when cpu is medium
+  tmux set-option -g @cpu_high_bg_color "$thm_red" # background color when cpu is high
+  
+  local index=$1
+  local icon=$(get_tmux_option "@catppuccin_cpu_icon" "")
+  local color="$(get_tmux_option "@catppuccin_cpu_color" "#{cpu_bg_color}")"
+  local text="$(get_tmux_option "@catppuccin_cpu_text" "#{cpu_percentage}")"
+
+  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+
+  echo "$module"
+}


### PR DESCRIPTION
CPU module
Requirements
This module depends on [`tmux-cpu`](https://github.com/tmux-plugins/tmux-cpu).

Install
The prefered way to install tmux-cpu is using [TPM](https://github.com/tmux-plugins/tpm).

Configure
Load tmux-cpu after you load catppuccin.

set -g @plugin 'catppuccin/tmux'
...
set -g @plugin 'tmux-plugins/tmux-cpu'
Add the cpu module to the status modules list.

set -g @catppuccin_status_modules" "... cpu ..."