### PR TITLE
Feature: Window BG Color

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ Values:
 - all - the entire window part will have the same color
 - none - the entire window part will have no color
 
+#### Override the window default colors:
+```sh
+set -g @catppuccin_window_default_text "color" # text color
+set -g @catppuccin_window_default_background "color"
+```
+
+Values:
+- color - a hexadecimal color value
+
 #### Override the window default text:
 ```sh
 set -g @catppuccin_window_default_text "#{b:pane_current_path}" # use "#W" for application instead of directory
@@ -156,6 +165,15 @@ Values:
 - number - only the number of the window part will have color
 - all - the entire window part will have the same color
 - none - the entire window part will have no color
+
+#### Override the window current colors:
+```sh
+set -g @catppuccin_window_current_color "color" # text color
+set -g @catppuccin_window_current_background "color"
+```
+
+Values:
+- color - a hexadecimal color value
 
 #### Override the window current text:
 ```sh

--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -1,7 +1,7 @@
 show_window_current_format() {
   local number="#I"
   local color=$(get_tmux_option "@catppuccin_window_current_color" "$thm_orange")
-  local background="$thm_bg"
+  local background=$(get_tmux_option "@catppuccin_window_current_background" "$thm_bg")
   local text="$(get_tmux_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   local fill="$(get_tmux_option "@catppuccin_window_current_fill" "number")" # number, all, none
 

--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -1,6 +1,6 @@
 show_window_current_format() {
   local number="#I"
-  local color="$thm_orange"
+  local color=$(get_tmux_option "@catppuccin_window_current_color" "$thm_orange")
   local background="$thm_bg"
   local text="$(get_tmux_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   local fill="$(get_tmux_option "@catppuccin_window_current_fill" "number")" # number, all, none

--- a/window/window_default_format.sh
+++ b/window/window_default_format.sh
@@ -1,6 +1,6 @@
 show_window_default_format() {
   local number="#I"
-  local color="$thm_blue"
+  local color=$(get_tmux_option "@catppuccin_window_default_color" "$thm_blue")
   local background=$(get_tmux_option "@catppuccin_window_default_background" "$thm_gray")
   local text="$(get_tmux_option "@catppuccin_window_default_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   local fill="$(get_tmux_option "@catppuccin_window_default_fill" "number")" # number, all, none

--- a/window/window_default_format.sh
+++ b/window/window_default_format.sh
@@ -1,10 +1,10 @@
 show_window_default_format() {
   local number="#I"
   local color="$thm_blue"
-  local background="$thm_gray"
+  local background=$(get_tmux_option "@catppuccin_window_default_background" "$thm_gray")
   local text="$(get_tmux_option "@catppuccin_window_default_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   local fill="$(get_tmux_option "@catppuccin_window_default_fill" "number")" # number, all, none
-  
+
   local default_window_format=$( build_window_format "$number" "$color" "$background" "$text" "$fill" )
 
   echo "$default_window_format"


### PR DESCRIPTION
Adding a variable to allow the modification of the current window while otherwise defaulting to the original orange. Likewise was done for the default window, but with the gray. The variable names used were kept honest to the existing variables.

Addresses:
#80

Relevant options added:

`set -g @catppuccin_window_current_color "#DDB6F2"`
`set -g @catppuccin_window_default_background "#333333"`