### PR TITLE
Use highlighted current window text background

### DIFF
--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -1,7 +1,7 @@
 show_window_current_format() {
   local number="#I"
   local color="$thm_orange"
-  local background="$thm_bg"
+  local background="$thm_black4"
   local text="$(get_tmux_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   local fill="$(get_tmux_option "@catppuccin_window_current_fill" "number")" # number, all, none
 


### PR DESCRIPTION
Changes current window text background color so it looks selected and it's separator icons don't disappear in the background:

Before:
<img width="378" alt="image" src="https://github.com/catppuccin/tmux/assets/160616/da1b539f-25ba-47b8-b9a0-243df46f06b5">

After:
<img width="355" alt="image" src="https://github.com/catppuccin/tmux/assets/160616/89078ebe-e7ae-4ad6-8911-8583bf9e3786">
