### PR TITLE
feat: allow customization of status module block edge separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,23 @@ Available modules:
 - date_time - display the date and time
 - [battery](#battery-module) - display the battery
 
+#### Set the module edge separator
+```sh
+set -g @catppuccin_status_modules_right_separator_left  " "  # default is @catppuccin_status_left_separator
+set -g @catppuccin_status_modules_right_separator_right " "  # default is @catppuccin_status_right_separator
+set -g @catppuccin_status_modules_left_separator_left   " "  # default is @catppuccin_status_left_separator
+set -g @catppuccin_status_modules_left_separator_right  " "  # default is @catppuccin_status_right_separator
+```
+
+### Set the module edge colors
+```sh
+set -g @catppuccin_status_modules_right_separator_left_color  "color"  # default is @catppuccin_[module_name]_color
+set -g @catppuccin_status_modules_right_separator_right_color "color"  # default is @catppuccin_[module_name]_color
+set -g @catppuccin_status_modules_left_separator_left_color   "color"  # default is @catppuccin_[module_name]_color
+set -g @catppuccin_status_modules_left_separator_right_color  "color"  # default is @catppuccin_[module_name]_color
+```
+
+
 ### Customizing modules
 
 Every module (except the module "session") supports the following overrides:

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -188,7 +188,18 @@ build_status_module() {
 
   if [ $(($index)) -eq 0  ]
   then
-      local show_left_separator="#[fg=$color,bg=$thm_bg,nobold,nounderscore,noitalics]$status_left_separator"
+    local left_edge_separator_color=$(get_tmux_option "@catppuccin_status_modules_${modules_side}_separator_left_color" "$color")
+    local left_edge_separator=$(get_tmux_option "@catppuccin_status_modules_${modules_side}_separator_left" "$status_left_separator")
+    local show_left_separator="#[fg=$left_edge_separator_color,bg=$thm_bg,nobold,nounderscore,noitalics]$left_edge_separator"
+  fi
+
+  modules_arr=($modules_list)
+  modules_len=$((${#modules_arr[@]} - 1 ))
+  if [ $(($index)) -eq $modules_len ]
+  then
+    local right_edge_separator_color=$(get_tmux_option "@catppuccin_status_modules_${modules_side}_separator_right_color" "$color")
+    local right_edge_separator=$(get_tmux_option "@catppuccin_status_modules_${modules_side}_separator_right" "$status_right_separator")
+    local show_right_separator="#[fg=$right_edge_separator_color,bg=$thm_bg,nobold,nounderscore,noitalics]$right_edge_separator"
   fi
 
   echo "$show_left_separator$show_icon$show_text$show_right_separator"
@@ -196,6 +207,7 @@ build_status_module() {
 
 load_modules() {
   local modules_list=$1
+  local modules_side=$2
 
   local modules_custom_path=$PLUGIN_DIR/custom
   local modules_status_path=$PLUGIN_DIR/status
@@ -204,20 +216,12 @@ load_modules() {
   local module_index=0;
   local module_name
   local loaded_modules
-  local IN=$modules_list
 
-  # https://stackoverflow.com/questions/918886/how-do-i-split-a-string-on-a-delimiter-in-bash#15988793
-  while [ "$IN" != "$iter" ] ;do
-    # extract the substring from start of string up to delimiter.
-    iter=${IN%% *}
-    # delete this first "element" AND next separator, from $IN.
-    IN="${IN#$iter }"
-    # Print (or doing anything with) the first "element".
-
-    module_name=$iter
+  for module_name in $modules_list;
+  do
 
     local module_path=$modules_custom_path/$module_name.sh
-    source $module_path
+    source $module_path 2>/dev/null
 
     if [ 0 -eq $? ]
     then
@@ -227,7 +231,7 @@ load_modules() {
     fi
 
     local module_path=$modules_status_path/$module_name.sh
-    source $module_path
+    source $module_path 2>/dev/null
 
     if [ 0 -eq $? ]
     then
@@ -237,7 +241,7 @@ load_modules() {
     fi
 
     local module_path=$modules_window_path/$module_name.sh
-    source $module_path
+    source $module_path 2>/dev/null
 
     if [ 0 -eq $? ]
     then
@@ -312,11 +316,11 @@ main() {
   local status_connect_separator=$(get_tmux_option "@catppuccin_status_connect_separator" "yes")
   local status_fill=$(get_tmux_option "@catppuccin_status_fill" "icon")
 
-  local status_modules_right=$(get_tmux_option "@catppuccin_status_modules_right" "application session")
-  local loaded_modules_right=$( load_modules "$status_modules_right")
-
   local status_modules_left=$(get_tmux_option "@catppuccin_status_modules_left" "")
-  local loaded_modules_left=$( load_modules "$status_modules_left")
+  local loaded_modules_left=$( load_modules "$status_modules_left" "left")
+
+  local status_modules_right=$(get_tmux_option "@catppuccin_status_modules_right" "application session")
+  local loaded_modules_right=$( load_modules "$status_modules_right" "right")
 
   set status-left "$loaded_modules_left"
   set status-right "$loaded_modules_right"

--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -1,7 +1,7 @@
 show_window_current_format() {
   local number="#I"
-  local color="$thm_orange"
-  local background="$thm_bg"
+  local color="$(get_tmux_option "@catppuccin_window_current_color" "$thm_orange")"
+  local background="$(get_tmux_option "@catppuccin_window_current_background" "$thm_gray")"
   local text="$(get_tmux_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   local fill="$(get_tmux_option "@catppuccin_window_current_fill" "number")" # number, all, none
 

--- a/window/window_default_format.sh
+++ b/window/window_default_format.sh
@@ -1,10 +1,10 @@
 show_window_default_format() {
   local number="#I"
-  local color="$thm_blue"
-  local background="$thm_gray"
+  local color="$(get_tmux_option "@catppuccin_window_default_color" "$thm_blue")"
+  local background="$(get_tmux_option "@catppuccin_window_default_background" "$thm_gray")"
   local text="$(get_tmux_option "@catppuccin_window_default_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   local fill="$(get_tmux_option "@catppuccin_window_default_fill" "number")" # number, all, none
-  
+
   local default_window_format=$( build_window_format "$number" "$color" "$background" "$text" "$fill" )
 
   echo "$default_window_format"


### PR DESCRIPTION
this change allows you to adjust the edges of the status modules array separate from the modules inside the array

#### Set the module edge separator
```sh
set -g @catppuccin_status_modules_right_separator_left  " "  # default is @catppuccin_status_left_separator
set -g @catppuccin_status_modules_right_separator_right " "  # default is @catppuccin_status_right_separator
set -g @catppuccin_status_modules_left_separator_left   " "  # default is @catppuccin_status_left_separator
set -g @catppuccin_status_modules_left_separator_right  " "  # default is @catppuccin_status_right_separator
```

### Set the module edge colors
```sh
set -g @catppuccin_status_modules_right_separator_left_color  "color"  # default is @catppuccin_[module_name]_color
set -g @catppuccin_status_modules_right_separator_right_color "color"  # default is @catppuccin_[module_name]_color
set -g @catppuccin_status_modules_left_separator_left_color   "color"  # default is @catppuccin_[module_name]_color
set -g @catppuccin_status_modules_left_separator_right_color  "color"  # default is @catppuccin_[module_name]_color
```

additionally i have included a second commit that allows you to adjust the [ current | default ]_current_window_[ color | background ]

these all have sane defaults and fallback options so this should not effect and existing users
Here is an example

![Screenshot 2023-12-04 at 6 01 28 PM](https://github.com/catppuccin/tmux/assets/14242442/13c237da-ab5f-4f97-af35-d8f6b7114e48)

## Example Configuration:
```sh
set -g @catppuccin_flavour 'mocha'
set -g @catppuccin_window_status_enable "yes"
set -g @catppuccin_window_status_icon_enable "yes"
set -g @catppuccin_window_left_separator "█"
set -g @catppuccin_window_right_separator "█"
set -g @catppuccin_window_number_position "left"
set -g @catppuccin_window_middle_separator "█"

set -g @catppuccin_window_default_fill "number"
 
set -g @catppuccin_window_current_fill "number"
set -g @catppuccin_window_current_text '#W'
set -g @catppuccin_window_default_text "#W"

set -g @catppuccin_status_fill "all"
set -g @catppuccin_status_connect_separator "yes"
set -g @catppuccin_status_right_separator_inverse "no"
set -g @catppuccin_status_left_separator "█"
set -g @catppuccin_status_right_separator "█"
set -g @catppuccin_status_modules_left_separator_left  " "
set -g @catppuccin_status_modules_right_separator_right " "
set -g @catppuccin_status_modules_left "session"
set -g @catppuccin_status_modules_right "application date_time"
```