### PR TITLE
feat(weather): add weather module for xamut/tmux-weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
    5. [Customizing modules](#customizing-modules)
    6. [Battery module](#battery-module)
    7. [CPU module](#CPU-module)
+   8. [Weather module](#weather-module)
 5. [Create a custom module](#create-a-custom-module)
 6. [Configuration Examples](#configuration-examples)
    1. [Config 1](#config-1)
@@ -345,6 +346,27 @@ set -g @plugin 'tmux-plugins/tmux-cpu'
 Add the cpu module to the status modules list.
 ```sh
 set -g @catppuccin_status_modules_right "... cpu ..."
+```
+
+### Weather module
+
+#### Requirements
+This module depends on [tmux-weather](https://github.com/xamut/tmux-weather).
+
+#### Install
+The prefered way to install tmux-cpu is using [TPM](https://github.com/tmux-plugins/tpm).
+
+#### Configure
+Load tmux-weather after you load catppuccin.
+```sh
+set -g @plugin 'catppuccin/tmux'
+...
+set -g @plugin 'xamut/tmux-weather'
+```
+
+Add the weather module to the status modules list.
+```sh
+set -g @catppuccin_status_modules_right "... weather ..."
 ```
 
 ## Create a custom module

--- a/status/weather.sh
+++ b/status/weather.sh
@@ -1,0 +1,11 @@
+# Requires https://github.com/xamut/tmux-weather.
+show_weather() {
+  local index=$1
+  local icon="$(get_tmux_option "@catppuccin_weather_icon" "")"
+  local color="$(get_tmux_option "@catppuccin_weather_color" "$thm_yellow")"
+  local text="$(get_tmux_option "@catppuccin_weather_text" "#{weather}")"
+
+  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+
+  echo "$module"
+}


### PR DESCRIPTION
Weather module
Requirements
This module depends on https://github.com/xamut/tmux-weather.

Install
The preferred way to install tmux-weather is using TPM.

Configure
Load tmux-weather after you load catppuccin.

set -g @plugin 'catppuccin/tmux'
...
set -g @plugin 'xamut/tmux-weather'

Add the weather module to the status modules list.

set -g @catppuccin_status_modules" "... weather ..."