### PR TITLE
feat(pane): different border color if pane_synchronized

### DIFF
--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -336,7 +336,10 @@ main() {
   local pane_status_enable=$(get_tmux_option "@catppuccin_pane_status_enabled" "no") # yes
   local pane_border_status=$(get_tmux_option "@catppuccin_pane_border_status" "off") # bottom
   local pane_border_style=$(get_tmux_option "@catppuccin_pane_border_style" "fg=${thm_gray}")
-  local pane_active_border_style=$(get_tmux_option "@catppuccin_pane_active_border_style" "fg=${thm_orange}")
+  local pane_active_border_style=$(\
+    get_tmux_option "@catppuccin_pane_active_border_style" \
+    "#{?pane_in_mode,fg=${thm_yellow},#{?pane_synchronized,fg=${thm_magenta},fg=${thm_orange}}}"
+  )
   local pane_left_separator=$(get_tmux_option "@catppuccin_pane_left_separator" "█")
   local pane_middle_separator=$(get_tmux_option "@catppuccin_pane_middle_separator" "█")
   local pane_right_separator=$(get_tmux_option "@catppuccin_pane_right_separator" "█")


### PR DESCRIPTION
In  default tmux, when multiple panes are displayed (i.e., not zoomed) and pane_synchronized is true (i.e., by using `:set synchronize-panes on`), the active pane's border color will change from green to red ([source link][tmux-link]). We should to retain this behavior.

[tmux-link]:https://github.com/tmux/tmux/blob/0b355ae8114511e1ff6359272b164f1cdf718e80/options-table.c#L969