### PR TITLE
docs(README.md) use correct option for default window color

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Values:
 
 #### Override the window default colors:
 ```sh
-set -g @catppuccin_window_default_text "color" # text color
+set -g @catppuccin_window_default_color "color" # text color
 set -g @catppuccin_window_default_background "color"
 ```
 


### PR DESCRIPTION
I noticed that the wrong option was being referred to on the documentation when setting the default window color.