### PR TITLE
feat(config): allow status bar to be disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ set -g @catppuccin_pane_active_border_style "fg=red" # Use a value compatible wi
 
 
 ### Status
+#### Set the default status bar visibility
+```sh
+set -g @catppuccin_status_default "off" # defaults to "on"
+```
 
 #### Set the status module left separator:
 ```sh

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -322,7 +322,8 @@ main() {
   local modules_pane_path=$PLUGIN_DIR/pane
 
   # status
-  set status "on"
+  local status_default=$(get_tmux_option "@catppuccin_status_default" "on")
+  set status "$status_default"
   set status-bg "${thm_bg}"
   set status-justify "left"
   set status-left-length "100"


### PR DESCRIPTION
This adds a new config entry for setting the default status bar visibility on load, rather than forcing it to be on by default. 