### PR TITLE
Add space to default window status icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ Values:
 
 #### Override windows status icons
 ```sh
-set -g @catppuccin_icon_window_last "󰖰"
-set -g @catppuccin_icon_window_current "󰖯"
-set -g @catppuccin_icon_window_zoom "󰁌"
-set -g @catppuccin_icon_window_mark "󰃀"
-set -g @catppuccin_icon_window_silent "󰂛"
-set -g @catppuccin_icon_window_activity "󰖲"
-set -g @catppuccin_icon_window_bell "󰂞"
+set -g @catppuccin_icon_window_last "󰖰 "
+set -g @catppuccin_icon_window_current "󰖯 "
+set -g @catppuccin_icon_window_zoom "󰁌 "
+set -g @catppuccin_icon_window_mark "󰃀 "
+set -g @catppuccin_icon_window_silent "󰂛 "
+set -g @catppuccin_icon_window_activity "󱅫 "
+set -g @catppuccin_icon_window_bell "󰂞 "
 ```
 
 ### Window default

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -37,14 +37,13 @@ setw() {
 
 build_window_icon() {
   local window_status_icon_enable=$(get_tmux_option "@catppuccin_window_status_icon_enable" "yes")
-
-  local custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰")
-  local custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯")
-  local custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌")
-  local custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀")
-  local custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛")
-  local custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󰖲")
-  local custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞")
+  local custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰 ")
+  local custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯 ")
+  local custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌 ")
+  local custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀 ")
+  local custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛 ")
+  local custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫 ")
+  local custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞 ")
 
   if [ "$window_status_icon_enable" = "yes" ]
   then


### PR DESCRIPTION
Sometimes the window status icons get crowded,
<img width="527" alt="image" src="https://github.com/catppuccin/tmux/assets/11025519/80380a0a-d68a-4e12-957b-9bc22acbef83">

After the change,
<img width="537" alt="image" src="https://github.com/catppuccin/tmux/assets/11025519/1dfe4001-ad8a-49fb-b017-74b61167c99e">
