### PR TITLE
feat(uptime): replace plugin with sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Available modules:
 - user - display the username
 - host - display the hostname
 - date_time - display the date and time
+- uptime - display the uptime
 - [battery](#battery-module) - display the battery
 
 ### Customizing modules
@@ -436,28 +437,6 @@ set -g @plugin 'jamesoff/tmux-loadavg'
 Add the load module to the status modules list.
 ```sh
 set -g @catppuccin_status_modules_right "... load ..."
-```
-
-### Uptime module
-
-#### Requirements
-This module depends on [tmux-uptime](https://github.com/robhurring/tmux-uptime).
-
-#### Install
-The preferred way to install tmux-uptime is using [TPM](https://github.com/tmux-plugins/tpm).
-
-#### Configure
-Load tmux-uptime after you load catppuccin.
-
-```sh
-set -g @plugin 'catppuccin/tmux'
-...
-set -g @plugin 'robhurring/tmux-uptime'
-```
-
-Add the uptime module to the status modules list.
-```sh
-set -g @catppuccin_status_modules_right "... uptime ..."
 ```
 
 ## Create a custom module

--- a/status/uptime.sh
+++ b/status/uptime.sh
@@ -1,11 +1,10 @@
-# Requires https://github.com/robhurring/tmux-uptime.
 show_uptime() {
   local index=$1
   local icon="$(get_tmux_option "@catppuccin_uptime_icon" "󰔟")"
   local color="$(get_tmux_option "@catppuccin_uptime_color" "$thm_green")"
-  local text="$(get_tmux_option "@catppuccin_uptime_text" "#{uptime}")"
+  local text="$(get_tmux_option "@catppuccin_uptime_text" "#(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* users.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')")"
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  local module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }


### PR DESCRIPTION
The uptime plugin has some issue with minute formatting.

The sed command is based on https://stackoverflow.com/a/28353785.

```bash
$ bash uptimes
03:14:20 up 1 min,  2 users,  load average: 2.28, 1.29, 0.50
         new: 1m
         old: 1 min
04:12:29 up 59 min,  5 users,  load average: 0.06, 0.08, 0.48
         new: 59m
         old: 59 min
05:14:09 up  2:01,  5 users,  load average: 0.13, 0.10, 0.45
         new: 2h 01m
         old: 2h 01m
03:13:19 up 1 day, 0 min,  8 users,  load average: 0.01, 0.04, 0.05
         new: 1d 0m
         old: 1d 0 min
04:13:19 up 1 day,  1:00,  8 users,  load average: 0.02, 0.05, 0.21
         new: 1d 1h 00m
         old: 1d 1h 00m
12:49:10 up 25 days, 21:30, 28 users,  load average: 0.50, 0.66, 0.52
         new: 25d 21h 30m
         old: 25d 21h 30m
```

```bash
$ cat uptimes.sh 
#!/usr/bin/env bash

while read line; do
    echo "$line"
    echo -en "\t new: "
    echo "$line" | sed 's/^[^,]*up *//; s/, *[[:digit:]]* users.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/'
    echo -en "\t old: "
    echo "$line" | awk -F, '{print $1,$2}' |
        sed 's/:/h /g;s/^.*up *//; s/ *[0-9]* user.*//;s/[0-9]$/&m/;s/ day. */d /g'
done <uptimes.txt
```
[uptimes.txt](https://github.com/catppuccin/tmux/files/14624136/uptimes.txt)
