### PR TITLE
fix(window_status): fix window space

### DIFF
--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -37,23 +37,31 @@ setw() {
 
 build_window_icon() {
   local window_status_icon_enable=$(get_tmux_option "@catppuccin_window_status_icon_enable" "yes")
-  local custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰 ")
-  local custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯 ")
-  local custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌 ")
-  local custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀 ")
-  local custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛 ")
-  local custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫 ")
-  local custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞 ")
+  local custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰")
+  local custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯")
+  local custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌")
+  local custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀")
+  local custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛")
+  local custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫")
+  local custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞")
 
   if [ "$window_status_icon_enable" = "yes" ]
   then
     # #!~[*-]MZ
-    local show_window_status="#{?window_activity_flag,${custom_icon_window_activity},}#{?window_bell_flag,${custom_icon_window_bell},}#{?window_silence_flag,${custom_icon_window_silent},}#{?window_active,${custom_icon_window_current},}#{?window_last_flag,${custom_icon_window_last},}#{?window_marked_flag,${custom_icon_window_mark},}#{?window_zoomed_flag,${custom_icon_window_zoom},}"
+    local show_window_status=""
+    show_window_status+="#{?window_activity_flag, ${custom_icon_window_activity},}"
+    show_window_status+="#{?window_bell_flag, ${custom_icon_window_bell},}"
+    show_window_status+="#{?window_silence_flag, ${custom_icon_window_silent},}"
+    show_window_status+="#{?window_active, ${custom_icon_window_current},}"
+    show_window_status+="#{?window_last_flag, ${custom_icon_window_last},}"
+    show_window_status+="#{?window_marked_flag, ${custom_icon_window_mark},}"
+    show_window_status+="#{?window_zoomed_flag, ${custom_icon_window_zoom},}"
+
   fi
 
   if [ "$window_status_icon_enable" = "no" ]
   then
-    local show_window_status="#F"
+    local show_window_status=" #F"
   fi
 
   echo "$show_window_status"
@@ -132,7 +140,7 @@ build_window_format() {
   if [ "$window_status_enable" = "yes" ]
   then
     local icon="$( build_window_icon )"
-    text="$text $icon"
+    text="$text$icon"
   fi
 
   if [ "$fill" = "none" ]


### PR DESCRIPTION
This PR makes it the responsibility of the theme to ensure that the correct space is set between the window text, window status icon and window status right separator.

Old:
<img width="1310" alt="Screenshot 2024-03-18 at 15 53 59" src="https://github.com/catppuccin/tmux/assets/3298487/61d8e84f-f8cf-4ea3-ab0a-c9d035bf406b">

New:
<img width="1312" alt="Screenshot 2024-03-18 at 15 53 11" src="https://github.com/catppuccin/tmux/assets/3298487/90a67709-4736-4799-9bb4-2dc4298850f1">