### PR TITLE
feat(status, window): add option to make overwrite status background …

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,25 @@
 ## Content
 
 1. [Themes](#themes)
-2. [Installation](#installation)
-3. [Overview](#overview)
-4. [Configuration options](#configuration-options)
+1. [Installation](#installation)
+1. [Overview](#overview)
+1. [Configuration options](#configuration-options)
    1. [Window](#window)
-   2. [Window default](#window-default)
-   3. [Window current](#window-current)
-   4. [Status](#status)
-   4. [Pane](#pane)
-   5. [Customizing modules](#customizing-modules)
-   6. [Battery module](#battery-module)
-   7. [CPU module](#CPU-module)
-   8. [Weather modules](#weather-modules)
-   9. [Load module](#load-module)
-   10. [Uptime module](#uptime-module)
-5. [Create a custom module](#create-a-custom-module)
-6. [Configuration Examples](#configuration-examples)
+   1. [Window default](#window-default)
+   1. [Window current](#window-current)
+   1. [Status](#status)
+   1. [Pane](#pane)
+   1. [Customizing modules](#customizing-modules)
+   1. [Battery module](#battery-module)
+   1. [CPU module](#CPU-module)
+   1. [Weather modules](#weather-modules)
+   1. [Load module](#load-module)
+   1. [Uptime module](#uptime-module)
+1. [Create a custom module](#create-a-custom-module)
+1. [Configuration Examples](#configuration-examples)
    1. [Config 1](#config-1)
-   2. [Config 2](#config-2)
-   3. [Config 3](#config-3)
+   1. [Config 2](#config-2)
+   1. [Config 3](#config-3)
 
 ## Themes
 
@@ -89,6 +89,11 @@ Style Guide][style-guide]. To add these customizations, add any of the following
 options to your Tmux configuration.
 
 ### Window
+
+### Set the window separator
+```sh
+set -g @catppuccin_window_separator ""
+```
 
 #### Set the window left separator:
 ```sh
@@ -221,6 +226,20 @@ set -g @catppuccin_pane_active_border_style "fg=red" # Use a value compatible wi
 #### Set the default status bar visibility
 ```sh
 set -g @catppuccin_status_default "off" # defaults to "on"
+
+```
+
+#### overwrite the default status bar background color
+```sh
+set -g @catppuccin_status_background "#a83232"
+```
+This will overwrite the status bar background:
+- use hex color codes for other colors
+- "default" will make the status bar transparent
+
+Note: you need to restart tmux for this to take effect: 
+```sh
+tmux kill-server & tmux
 ```
 
 #### Set the status module left separator:

--- a/README.md
+++ b/README.md
@@ -229,13 +229,14 @@ set -g @catppuccin_status_default "off" # defaults to "on"
 
 ```
 
-#### overwrite the default status bar background color
+#### Override the default status background color
 ```sh
-set -g @catppuccin_status_background "#a83232"
+set -g @catppuccin_status_background "theme"
 ```
 This will overwrite the status bar background:
-- use hex color codes for other colors
+- "theme" will use the color from the selected theme
 - "default" will make the status bar transparent
+- use hex color codes for other colors
 
 Note: you need to restart tmux for this to take effect: 
 ```sh

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -301,12 +301,18 @@ load_modules() {
 }
 
 main() {
-  local theme
-  theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
-
   # Aggregate all commands in one array
   local tmux_commands=()
 
+  # module directories
+  local custom_path="$(get_tmux_option "@catppuccin_custom_plugin_dir" "${PLUGIN_DIR}/custom")"
+  local modules_custom_path=$custom_path
+  local modules_status_path=$PLUGIN_DIR/status
+  local modules_window_path=$PLUGIN_DIR/window
+  local modules_pane_path=$PLUGIN_DIR/pane
+
+  # load local theme
+  local theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
   # shellcheck source=catppuccin-frappe.tmuxtheme
@@ -321,22 +327,29 @@ main() {
       eval "local $key"="$val"
   done < "${PLUGIN_DIR}/catppuccin-${theme}.tmuxtheme"
 
-  # module directories
-  local custom_path="$(get_tmux_option "@catppuccin_custom_plugin_dir" "${PLUGIN_DIR}/custom")"
-  local modules_custom_path=$custom_path
-  local modules_status_path=$PLUGIN_DIR/status
-  local modules_window_path=$PLUGIN_DIR/window
-  local modules_pane_path=$PLUGIN_DIR/pane
-
-  # status
+  # status general
   local status_default=$(get_tmux_option "@catppuccin_status_default" "on")
-  local status_justify=$(get_tmux_option "@catppuccin_status_justify" "left")
-
   set status "$status_default"
+
+  local status_justify=$(get_tmux_option "@catppuccin_status_justify" "left")
   set status-justify "$status_justify"
-  set status-bg "${thm_bg}"
+
+  local status_background=$(get_tmux_option "@catppuccin_status_background" "theme")
+  if [ "${status_background}" = "theme" ];
+  then
+    set status-bg "${thm_bg}"
+  else
+    if [ "${status_background}" = "default" ]
+    then
+      set status-style bg=default
+    else
+      set status-bg "${status_background}"
+    fi
+  fi
+
   set status-left-length "100"
   set status-right-length "100"
+
 
   # messages
   set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
@@ -361,13 +374,12 @@ main() {
   setw pane-border-style "$pane_border_style"
   setw pane-border-format "$pane_format"
 
+  # window
+  local window_status_separator=$(get_tmux_option "@catppuccin_window_separator" "")
+  setw window-status-separator "$window_status_separator"
 
-  # windows
   setw window-status-activity-style "fg=${thm_fg},bg=${thm_bg},none"
-  setw window-status-separator ""
   setw window-status-style "fg=${thm_fg},bg=${thm_bg},none"
-
-  # --------=== Statusline
 
   local window_left_separator=$(get_tmux_option "@catppuccin_window_left_separator" "█")
   local window_right_separator=$(get_tmux_option "@catppuccin_window_right_separator" "█")
@@ -376,28 +388,27 @@ main() {
   local window_status_enable=$(get_tmux_option "@catppuccin_window_status_enable" "no") # right, left
 
   local window_format=$(load_modules "window_default_format" "$modules_custom_path" "$modules_window_path")
-  local window_current_format=$(load_modules "window_current_format" "$modules_custom_path" "$modules_window_path")
-
   setw window-status-format "$window_format"
+
+  local window_current_format=$(load_modules "window_current_format" "$modules_custom_path" "$modules_window_path")
   setw window-status-current-format "$window_current_format"
 
+  # status module
   local status_left_separator=$(get_tmux_option "@catppuccin_status_left_separator" "")
   local status_right_separator=$(get_tmux_option "@catppuccin_status_right_separator" "█")
   local status_right_separator_inverse=$(get_tmux_option "@catppuccin_status_right_separator_inverse" "no")
   local status_connect_separator=$(get_tmux_option "@catppuccin_status_connect_separator" "yes")
   local status_fill=$(get_tmux_option "@catppuccin_status_fill" "icon")
 
-  local status_modules_right=$(get_tmux_option "@catppuccin_status_modules_right" "application session")
-  local loaded_modules_right=$(load_modules "$status_modules_right" "$modules_custom_path" "$modules_status_path")
-
   local status_modules_left=$(get_tmux_option "@catppuccin_status_modules_left" "")
   local loaded_modules_left=$(load_modules "$status_modules_left" "$modules_custom_path" "$modules_status_path")
-
   set status-left "$loaded_modules_left"
+
+  local status_modules_right=$(get_tmux_option "@catppuccin_status_modules_right" "application session")
+  local loaded_modules_right=$(load_modules "$status_modules_right" "$modules_custom_path" "$modules_status_path")
   set status-right "$loaded_modules_right"
 
-  # --------=== Modes
-  #
+  # modes
   setw clock-mode-colour "${thm_blue}"
   setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"
 

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -37,23 +37,31 @@ setw() {
 
 build_window_icon() {
   local window_status_icon_enable=$(get_tmux_option "@catppuccin_window_status_icon_enable" "yes")
-  local custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰 ")
-  local custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯 ")
-  local custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌 ")
-  local custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀 ")
-  local custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛 ")
-  local custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫 ")
-  local custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞 ")
+  local custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰")
+  local custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯")
+  local custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌")
+  local custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀")
+  local custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛")
+  local custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫")
+  local custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞")
 
   if [ "$window_status_icon_enable" = "yes" ]
   then
     # #!~[*-]MZ
-    local show_window_status="#{?window_activity_flag,${custom_icon_window_activity},}#{?window_bell_flag,${custom_icon_window_bell},}#{?window_silence_flag,${custom_icon_window_silent},}#{?window_active,${custom_icon_window_current},}#{?window_last_flag,${custom_icon_window_last},}#{?window_marked_flag,${custom_icon_window_mark},}#{?window_zoomed_flag,${custom_icon_window_zoom},}"
+    local show_window_status=""
+    show_window_status+="#{?window_activity_flag, ${custom_icon_window_activity},}"
+    show_window_status+="#{?window_bell_flag, ${custom_icon_window_bell},}"
+    show_window_status+="#{?window_silence_flag, ${custom_icon_window_silent},}"
+    show_window_status+="#{?window_active, ${custom_icon_window_current},}"
+    show_window_status+="#{?window_last_flag, ${custom_icon_window_last},}"
+    show_window_status+="#{?window_marked_flag, ${custom_icon_window_mark},}"
+    show_window_status+="#{?window_zoomed_flag, ${custom_icon_window_zoom},}"
+
   fi
 
   if [ "$window_status_icon_enable" = "no" ]
   then
-    local show_window_status="#F"
+    local show_window_status=" #F"
   fi
 
   echo "$show_window_status"
@@ -132,7 +140,7 @@ build_window_format() {
   if [ "$window_status_enable" = "yes" ]
   then
     local icon="$( build_window_icon )"
-    text="$text $icon"
+    text="$text$icon"
   fi
 
   if [ "$fill" = "none" ]


### PR DESCRIPTION
This PR adds 2 new options

### Set the window separator
```sh
set -g @catppuccin_window_separator ""
```

#### Override the default status bar background color
```sh
set -g @catppuccin_status_background "theme"
```
This will overwrite the status bar background:
- "theme" will use the color from the selected theme
- "default" will make the status bar transparent
- use hex color codes for other colors

This should fix issues:
- https://github.com/catppuccin/tmux/issues/134
- https://github.com/catppuccin/tmux/issues/87
- https://github.com/catppuccin/tmux/issues/84