### PR TITLE
Cleanup shellcheck warnings

### DIFF
--- a/.github/scripts/test.bash
+++ b/.github/scripts/test.bash
@@ -59,7 +59,7 @@ main() {
     exit 1
   else
     echo "Running plugin: $plugin" >&2
-    output=$(tmux run-shell "$plugin" 2>&2)
+    output=$(tmux run-shell "$plugin" 2>&1)
     exit_code="$?"
 
     check "$exit_code" "$output"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -27,7 +27,4 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
-          severity: error
           additional_files: "catppuccin.tmux"
-        env:
-          SHELLCHECK_OPTS: "-s bash"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -26,5 +26,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
-        with:
-          additional_files: "catppuccin.tmux"
+        env:
+          SHELLCHECK_OPTS: "-a"

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,6 @@
+shell=bash
+
+# TODO: Find a way to declare color variables
+disable=SC2154
+
+external-sources=true

--- a/builder/module_builder.sh
+++ b/builder/module_builder.sh
@@ -36,7 +36,7 @@ build_status_module() {
 
   fi
 
-  if [ $(($index)) -eq 0 ]; then
+  if [ $((index)) -eq 0 ]; then
     local show_left_separator="#[fg=$color,bg=default,nobold,nounderscore,noitalics]$status_left_separator"
   fi
 

--- a/builder/window_builder.sh
+++ b/builder/window_builder.sh
@@ -8,7 +8,8 @@ build_window_format() {
   local fill="$5"
 
   if [ "$window_status_enable" = "yes" ]; then
-    local icon="$(build_window_icon)"
+    local icon
+    icon="$(build_window_icon)"
     text="$text$icon"
   fi
 
@@ -92,14 +93,18 @@ build_window_format() {
 }
 
 build_window_icon() {
-  local window_status_icon_enable=$(get_tmux_option "@catppuccin_window_status_icon_enable" "yes")
-  local custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰")
-  local custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯")
-  local custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌")
-  local custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀")
-  local custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛")
-  local custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫")
-  local custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞")
+  local window_status_icon_enable custom_icon_window_last \
+    custom_icon_window_zoom custom_icon_window_mark custom_icon_window_mark \
+    custom_icon_window_silent custom_icon_window_activity custom_icon_window_bell
+
+  window_status_icon_enable=$(get_tmux_option "@catppuccin_window_status_icon_enable" "yes")
+  custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰")
+  custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯")
+  custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌")
+  custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀")
+  custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛")
+  custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫")
+  custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞")
 
   if [ "$window_status_icon_enable" = "yes" ]; then
     # #!~[*-]MZ

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2154
 
 # Set path of script
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # import
+# shellcheck source=./builder/module_builder.sh
 source "${PLUGIN_DIR}/builder/module_builder.sh"
+# shellcheck source=./builder/window_builder.sh
 source "${PLUGIN_DIR}/builder/window_builder.sh"
+# shellcheck source=./builder/pane_builder.sh
 source "${PLUGIN_DIR}/builder/pane_builder.sh"
+# shellcheck source=./utils/tmux_utils.sh
 source "${PLUGIN_DIR}/utils/tmux_utils.sh"
+# shellcheck source=./utils/module_utils.sh
 source "${PLUGIN_DIR}/utils/module_utils.sh"
 
 main() {
@@ -15,18 +21,20 @@ main() {
   local tmux_commands=()
 
   # module directories
-  local custom_path="$(get_tmux_option "@catppuccin_custom_plugin_dir" "${PLUGIN_DIR}/custom")"
-  local modules_custom_path=$custom_path
-  local modules_status_path=$PLUGIN_DIR/status
-  local modules_window_path=$PLUGIN_DIR/window
-  local modules_pane_path=$PLUGIN_DIR/pane
+  local custom_path modules_custom_path modules_status_path modules_window_path modules_pane_path
+  custom_path="$(get_tmux_option "@catppuccin_custom_plugin_dir" "${PLUGIN_DIR}/custom")"
+  modules_custom_path=$custom_path
+  modules_status_path=$PLUGIN_DIR/status
+  modules_window_path=$PLUGIN_DIR/window
+  modules_pane_path=$PLUGIN_DIR/pane
 
   # load local theme
-  local theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
+  local theme
+  theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
-  # shellcheck source=catppuccin-frappe.tmuxtheme
   # https://github.com/dylanaraps/pure-sh-bible#parsing-a-keyval-file
+  # shellcheck source=./catppuccin-frappe.tmuxtheme
   while IFS='=' read -r key val; do
     # Skip over lines containing comments.
     # (Lines starting with '#').
@@ -38,13 +46,15 @@ main() {
   done <"${PLUGIN_DIR}/catppuccin-${theme}.tmuxtheme"
 
   # status general
-  local status_default=$(get_tmux_option "@catppuccin_status_default" "on")
+  local status_default status_justify status_background
+  status_default=$(get_tmux_option "@catppuccin_status_default" "on")
+  # shellcheck disable=SC2121
   set status "$status_default"
 
-  local status_justify=$(get_tmux_option "@catppuccin_status_justify" "left")
+  status_justify=$(get_tmux_option "@catppuccin_status_justify" "left")
   set status-justify "$status_justify"
 
-  local status_background=$(get_tmux_option "@catppuccin_status_background" "theme")
+  status_background=$(get_tmux_option "@catppuccin_status_background" "theme")
   if [ "${status_background}" = "theme" ]; then
     set status-bg "${thm_bg}"
   else
@@ -63,18 +73,21 @@ main() {
   set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
 
   # panes
-  local pane_status_enable=$(get_tmux_option "@catppuccin_pane_status_enabled" "no") # yes
-  local pane_border_status=$(get_tmux_option "@catppuccin_pane_border_status" "off") # bottom
-  local pane_border_style=$(get_tmux_option "@catppuccin_pane_border_style" "fg=${thm_gray}")
-  local pane_active_border_style=$(
+  local pane_border_status pane_border_style \
+    pane_active_border_style pane_left_separator pane_middle_separator \
+    pane_right_separator pane_number_position pane_format
+  pane_status_enable=$(get_tmux_option "@catppuccin_pane_status_enabled" "no") # yes
+  pane_border_status=$(get_tmux_option "@catppuccin_pane_border_status" "off") # bottom
+  pane_border_style=$(get_tmux_option "@catppuccin_pane_border_style" "fg=${thm_gray}")
+  pane_active_border_style=$(
     get_tmux_option "@catppuccin_pane_active_border_style" \
       "#{?pane_in_mode,fg=${thm_yellow},#{?pane_synchronized,fg=${thm_magenta},fg=${thm_orange}}}"
   )
-  local pane_left_separator=$(get_tmux_option "@catppuccin_pane_left_separator" "█")
-  local pane_middle_separator=$(get_tmux_option "@catppuccin_pane_middle_separator" "█")
-  local pane_right_separator=$(get_tmux_option "@catppuccin_pane_right_separator" "█")
-  local pane_number_position=$(get_tmux_option "@catppuccin_pane_number_position" "left") # right, left
-  local pane_format=$(load_modules "pane_default_format" "$modules_custom_path" "$modules_pane_path")
+  pane_left_separator=$(get_tmux_option "@catppuccin_pane_left_separator" "█")
+  pane_middle_separator=$(get_tmux_option "@catppuccin_pane_middle_separator" "█")
+  pane_right_separator=$(get_tmux_option "@catppuccin_pane_right_separator" "█")
+  pane_number_position=$(get_tmux_option "@catppuccin_pane_number_position" "left") # right, left
+  pane_format=$(load_modules "pane_default_format" "$modules_custom_path" "$modules_pane_path")
 
   setw pane-border-status "$pane_border_status"
   setw pane-active-border-style "$pane_active_border_style"
@@ -82,34 +95,39 @@ main() {
   setw pane-border-format "$pane_format"
 
   # window
-  local window_status_separator=$(get_tmux_option "@catppuccin_window_separator" "")
+  local window_status_separator window_left_separator window_right_separator \
+    window_middle_separator window_number_position window_status_enable \
+    window_format window_current_format
+
+  window_status_separator=$(get_tmux_option "@catppuccin_window_separator" "")
   setw window-status-separator "$window_status_separator"
 
-  local window_left_separator=$(get_tmux_option "@catppuccin_window_left_separator" "█")
-  local window_right_separator=$(get_tmux_option "@catppuccin_window_right_separator" "█")
-  local window_middle_separator=$(get_tmux_option "@catppuccin_window_middle_separator" "█ ")
-  local window_number_position=$(get_tmux_option "@catppuccin_window_number_position" "left") # right, left
-  local window_status_enable=$(get_tmux_option "@catppuccin_window_status_enable" "no")       # right, left
+  window_left_separator=$(get_tmux_option "@catppuccin_window_left_separator" "█")
+  window_right_separator=$(get_tmux_option "@catppuccin_window_right_separator" "█")
+  window_middle_separator=$(get_tmux_option "@catppuccin_window_middle_separator" "█ ")
+  window_number_position=$(get_tmux_option "@catppuccin_window_number_position" "left") # right, left
+  window_status_enable=$(get_tmux_option "@catppuccin_window_status_enable" "no")       # right, left
 
-  local window_format=$(load_modules "window_default_format" "$modules_custom_path" "$modules_window_path")
+  window_format=$(load_modules "window_default_format" "$modules_custom_path" "$modules_window_path")
   setw window-status-format "$window_format"
 
-  local window_current_format=$(load_modules "window_current_format" "$modules_custom_path" "$modules_window_path")
+  window_current_format=$(load_modules "window_current_format" "$modules_custom_path" "$modules_window_path")
   setw window-status-current-format "$window_current_format"
 
   # status module
-  local status_left_separator=$(get_tmux_option "@catppuccin_status_left_separator" "")
-  local status_right_separator=$(get_tmux_option "@catppuccin_status_right_separator" "█")
-  local status_right_separator_inverse=$(get_tmux_option "@catppuccin_status_right_separator_inverse" "no")
-  local status_connect_separator=$(get_tmux_option "@catppuccin_status_connect_separator" "yes")
-  local status_fill=$(get_tmux_option "@catppuccin_status_fill" "icon")
+  local status_left_separator status_right_separator status_connect_separator \
+    status_fill status_modules_left status_modules_right
+  status_left_separator=$(get_tmux_option "@catppuccin_status_left_separator" "")
+  status_right_separator=$(get_tmux_option "@catppuccin_status_right_separator" "█")
+  status_connect_separator=$(get_tmux_option "@catppuccin_status_connect_separator" "yes")
+  status_fill=$(get_tmux_option "@catppuccin_status_fill" "icon")
 
-  local status_modules_left=$(get_tmux_option "@catppuccin_status_modules_left" "")
-  local loaded_modules_left=$(load_modules "$status_modules_left" "$modules_custom_path" "$modules_status_path")
+  status_modules_left=$(get_tmux_option "@catppuccin_status_modules_left" "")
+  loaded_modules_left=$(load_modules "$status_modules_left" "$modules_custom_path" "$modules_status_path")
   set status-left "$loaded_modules_left"
 
-  local status_modules_right=$(get_tmux_option "@catppuccin_status_modules_right" "application session")
-  local loaded_modules_right=$(load_modules "$status_modules_right" "$modules_custom_path" "$modules_status_path")
+  status_modules_right=$(get_tmux_option "@catppuccin_status_modules_right" "application session")
+  loaded_modules_right=$(load_modules "$status_modules_right" "$modules_custom_path" "$modules_status_path")
   set status-right "$loaded_modules_right"
 
   # modes

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2154
 
 # Set path of script
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/pane/pane_default_format.sh
+++ b/pane/pane_default_format.sh
@@ -1,12 +1,13 @@
 show_pane_default_format() {
-  local number="#{pane_index}"
-  local color="$(get_tmux_option "@catppuccin_pane_color" "$thm_green")"
-  local background="$(get_tmux_option "@catppuccin_pane_background_color" "$thm_gray")"
-  local text="$(get_tmux_option "@catppuccin_pane_default_text" "#{b:pane_current_path}")"
-  local fill="$(get_tmux_option "@catppuccin_pane_default_fill" "number")" # number, all, none
-  local active="#{pane_active}"
+  local number color background text fill
 
-  local default_pane_format=$( build_pane_format "$number" "$color" "$background" "$text" "$fill")
+  number="#{pane_index}"
+  color="$(get_tmux_option "@catppuccin_pane_color" "$thm_green")"
+  background="$(get_tmux_option "@catppuccin_pane_background_color" "$thm_gray")"
+  text="$(get_tmux_option "@catppuccin_pane_default_text" "#{b:pane_current_path}")"
+  fill="$(get_tmux_option "@catppuccin_pane_default_fill" "number")" # number, all, none
+
+  default_pane_format=$(build_pane_format "$number" "$color" "$background" "$text" "$fill")
 
   echo "$default_pane_format"
 }

--- a/status/application.sh
+++ b/status/application.sh
@@ -1,10 +1,12 @@
 show_application() {
-  local index=$1
-  local icon=$(get_tmux_option "@catppuccin_application_icon" "")
-  local color=$(get_tmux_option "@catppuccin_application_color" "$thm_pink")
-  local text=$(get_tmux_option "@catppuccin_application_text" "#W")
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon=$(get_tmux_option "@catppuccin_application_icon" "")
+  color=$(get_tmux_option "@catppuccin_application_color" "$thm_pink")
+  text=$(get_tmux_option "@catppuccin_application_text" "#W")
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/battery.sh
+++ b/status/battery.sh
@@ -1,4 +1,11 @@
 show_battery() {
+  local index icon color text module
+
+  index=$1
+  icon=$(get_tmux_option "@catppuccin_battery_icon" "#{battery_icon}")
+  color=$(get_tmux_option "@catppuccin_battery_color" "$thm_yellow")
+  text=$(get_tmux_option "@catppuccin_battery_text" "#{battery_percentage}")
+
   tmux set-option -g @batt_icon_charge_tier8 '󰁹'
   tmux set-option -g @batt_icon_charge_tier7 '󰂁'
   tmux set-option -g @batt_icon_charge_tier6 '󰁿'
@@ -12,12 +19,7 @@ show_battery() {
   tmux set-option -g @batt_icon_status_discharging '󰂃'
   tmux set-option -g @batt_icon_status_unknown '󰂑'
 
-  local index=$1
-  local icon=$(get_tmux_option "@catppuccin_battery_icon" "#{battery_icon}")
-  local color=$(get_tmux_option "@catppuccin_battery_color" "$thm_yellow")
-  local text=$(get_tmux_option "@catppuccin_battery_text" "#{battery_percentage}")
-
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/clima.sh
+++ b/status/clima.sh
@@ -1,11 +1,13 @@
 # Requires https://github.com/vascomfnunes/tmux-clima
 show_clima() {
-  local index=$1
-  local icon="$(get_tmux_option "@catppuccin_clima_icon" "")"
-  local color="$(get_tmux_option "@catppuccin_clima_color" "$thm_yellow")"
-  local text="$(get_tmux_option "@catppuccin_clima_text" "#{clima}")"
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon="$(get_tmux_option "@catppuccin_clima_icon" "")"
+  color="$(get_tmux_option "@catppuccin_clima_color" "$thm_yellow")"
+  text="$(get_tmux_option "@catppuccin_clima_text" "#{clima}")"
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/cpu.sh
+++ b/status/cpu.sh
@@ -1,14 +1,16 @@
 show_cpu() {
-  tmux set-option -g @cpu_low_bg_color "$thm_yellow" # background color when cpu is low
-  tmux set-option -g @cpu_medium_bg_color "$thm_orange" # background color when cpu is medium
-  tmux set-option -g @cpu_high_bg_color "$thm_red" # background color when cpu is high
-  
-  local index=$1
-  local icon=$(get_tmux_option "@catppuccin_cpu_icon" "")
-  local color="$(get_tmux_option "@catppuccin_cpu_color" "#{cpu_bg_color}")"
-  local text="$(get_tmux_option "@catppuccin_cpu_text" "#{cpu_percentage}")"
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon=$(get_tmux_option "@catppuccin_cpu_icon" "")
+  color="$(get_tmux_option "@catppuccin_cpu_color" "#{cpu_bg_color}")"
+  text="$(get_tmux_option "@catppuccin_cpu_text" "#{cpu_percentage}")"
+
+  tmux set-option -g @cpu_low_bg_color "$thm_yellow"    # background color when cpu is low
+  tmux set-option -g @cpu_medium_bg_color "$thm_orange" # background color when cpu is medium
+  tmux set-option -g @cpu_high_bg_color "$thm_red"      # background color when cpu is high
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/date_time.sh
+++ b/status/date_time.sh
@@ -1,11 +1,12 @@
 show_date_time() {
-  local index=$1
-  local icon="$(get_tmux_option "@catppuccin_date_time_icon" "󰃰")"
-  local color="$(get_tmux_option "@catppuccin_date_time_color" "$thm_blue")"
-  local text="$(get_tmux_option "@catppuccin_date_time_text" "%Y-%m-%d %H:%M")"
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon="$(get_tmux_option "@catppuccin_date_time_icon" "󰃰")"
+  color="$(get_tmux_option "@catppuccin_date_time_color" "$thm_blue")"
+  text="$(get_tmux_option "@catppuccin_date_time_text" "%Y-%m-%d %H:%M")"
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }
-

--- a/status/directory.sh
+++ b/status/directory.sh
@@ -1,10 +1,12 @@
 show_directory() {
-  local index=$1
-  local icon=$(get_tmux_option "@catppuccin_directory_icon" "")
-  local color=$(get_tmux_option "@catppuccin_directory_color" "$thm_pink")
-  local text=$(get_tmux_option "@catppuccin_directory_text" "#{b:pane_current_path}")
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon=$(get_tmux_option "@catppuccin_directory_icon" "")
+  color=$(get_tmux_option "@catppuccin_directory_color" "$thm_pink")
+  text=$(get_tmux_option "@catppuccin_directory_text" "#{b:pane_current_path}")
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/host.sh
+++ b/status/host.sh
@@ -1,10 +1,12 @@
 show_host() {
-  local index=$1
-  local icon=$(get_tmux_option "@catppuccin_host_icon" "󰒋")
-  local color=$(get_tmux_option "@catppuccin_host_color" "$thm_magenta")
-  local text=$(get_tmux_option "@catppuccin_host_text" "#H")
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon=$(get_tmux_option "@catppuccin_host_icon" "󰒋")
+  color=$(get_tmux_option "@catppuccin_host_color" "$thm_magenta")
+  text=$(get_tmux_option "@catppuccin_host_text" "#H")
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/load.sh
+++ b/status/load.sh
@@ -1,11 +1,12 @@
 show_load() {
-  local index=$1
-  local icon="$(get_tmux_option "@catppuccin_load_icon" "󰊚")"
-  local color="$(get_tmux_option "@catppuccin_load_color" "$thm_blue")"
-  local text="$(get_tmux_option "@catppuccin_load_text" "#{load_full}")"
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon="$(get_tmux_option "@catppuccin_load_icon" "󰊚")"
+  color="$(get_tmux_option "@catppuccin_load_color" "$thm_blue")"
+  text="$(get_tmux_option "@catppuccin_load_text" "#{load_full}")"
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }
-

--- a/status/session.sh
+++ b/status/session.sh
@@ -1,10 +1,12 @@
 show_session() {
-  local index=$1
-  local icon=$(get_tmux_option "@catppuccin_session_icon" "")
-  local color=$(get_tmux_option "@catppuccin_session_color" "#{?client_prefix,$thm_red,$thm_green}")
-  local text=$(get_tmux_option "@catppuccin_session_text" "#S")
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon=$(get_tmux_option "@catppuccin_session_icon" "")
+  color=$(get_tmux_option "@catppuccin_session_color" "#{?client_prefix,$thm_red,$thm_green}")
+  text=$(get_tmux_option "@catppuccin_session_text" "#S")
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/uptime.sh
+++ b/status/uptime.sh
@@ -1,10 +1,12 @@
 show_uptime() {
-  local index=$1
-  local icon="$(get_tmux_option "@catppuccin_uptime_icon" "󰔟")"
-  local color="$(get_tmux_option "@catppuccin_uptime_color" "$thm_green")"
-  local text="$(get_tmux_option "@catppuccin_uptime_text" "#(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* users.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')")"
+  local index icon color text module
 
-  local module=$(build_status_module "$index" "$icon" "$color" "$text")
+  index=$1
+  icon="$(get_tmux_option "@catppuccin_uptime_icon" "󰔟")"
+  color="$(get_tmux_option "@catppuccin_uptime_color" "$thm_green")"
+  text="$(get_tmux_option "@catppuccin_uptime_text" "#(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* users.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')")"
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/user.sh
+++ b/status/user.sh
@@ -1,10 +1,12 @@
 show_user() {
-  local index=$1
-  local icon=$(get_tmux_option "@catppuccin_user_icon" "")
-  local color=$(get_tmux_option "@catppuccin_user_color" "$thm_cyan")
-  local text=$(get_tmux_option "@catppuccin_user_text" "#(whoami)")
+  local index icon color text module
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  index=$1
+  icon=$(get_tmux_option "@catppuccin_user_icon" "")
+  color=$(get_tmux_option "@catppuccin_user_color" "$thm_cyan")
+  text=$(get_tmux_option "@catppuccin_user_text" "#(whoami)")
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/weather.sh
+++ b/status/weather.sh
@@ -1,11 +1,14 @@
 # Requires https://github.com/xamut/tmux-weather.
-show_weather() {
-  local index=$1
-  local icon="$(get_tmux_option "@catppuccin_weather_icon" "")"
-  local color="$(get_tmux_option "@catppuccin_weather_color" "$thm_yellow")"
-  local text="$(get_tmux_option "@catppuccin_weather_text" "#{weather}")"
 
-  local module=$( build_status_module "$index" "$icon" "$color" "$text" )
+show_weather() {
+  local index icon color text module
+
+  index=$1
+  icon="$(get_tmux_option "@catppuccin_weather_icon" "")"
+  color="$(get_tmux_option "@catppuccin_weather_color" "$thm_yellow")"
+  text="$(get_tmux_option "@catppuccin_weather_text" "#{weather}")"
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/utils/module_utils.sh
+++ b/utils/module_utils.sh
@@ -16,7 +16,7 @@ load_modules() {
     # extract the substring from start of string up to delimiter.
     iter=${IN%% *}
     # delete this first "element" AND next separator, from $IN.
-    IN="${IN#$iter }"
+    IN="${IN#"$iter "}"
     # Print (or doing anything with) the first "element".
 
     module_name=$iter
@@ -25,6 +25,7 @@ load_modules() {
       module_path="$module_dir/$module_name.sh"
 
       if [ -r "$module_path" ]; then
+        # shellcheck source=/dev/null
         source "$module_path"
         loaded_modules="$loaded_modules$( "show_$module_name" "$module_index" )"
         module_index+=1

--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -1,11 +1,13 @@
 show_window_current_format() {
-  local number="#I"
-  local color=$(get_tmux_option "@catppuccin_window_current_color" "$thm_orange")
-  local background=$(get_tmux_option "@catppuccin_window_current_background" "$thm_bg")
-  local text="$(get_tmux_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
-  local fill="$(get_tmux_option "@catppuccin_window_current_fill" "number")" # number, all, none
+  local number color background text fill current_window_format
 
-  local current_window_format=$( build_window_format "$number" "$color" "$background" "$text" "$fill" )
+  number="#I"
+  color=$(get_tmux_option "@catppuccin_window_current_color" "$thm_orange")
+  background=$(get_tmux_option "@catppuccin_window_current_background" "$thm_bg")
+  text="$(get_tmux_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
+  fill="$(get_tmux_option "@catppuccin_window_current_fill" "number")"                 # number, all, none
+
+  current_window_format=$(build_window_format "$number" "$color" "$background" "$text" "$fill")
 
   echo "$current_window_format"
 }

--- a/window/window_default_format.sh
+++ b/window/window_default_format.sh
@@ -1,11 +1,13 @@
 show_window_default_format() {
-  local number="#I"
-  local color=$(get_tmux_option "@catppuccin_window_default_color" "$thm_blue")
-  local background=$(get_tmux_option "@catppuccin_window_default_background" "$thm_gray")
-  local text="$(get_tmux_option "@catppuccin_window_default_text" "#{b:pane_current_path}")" # use #W for application instead of directory
-  local fill="$(get_tmux_option "@catppuccin_window_default_fill" "number")" # number, all, none
+  local number color background text fill default_window_format
 
-  local default_window_format=$( build_window_format "$number" "$color" "$background" "$text" "$fill" )
+  number="#I"
+  color=$(get_tmux_option "@catppuccin_window_default_color" "$thm_blue")
+  background=$(get_tmux_option "@catppuccin_window_default_background" "$thm_gray")
+  text="$(get_tmux_option "@catppuccin_window_default_text" "#{b:pane_current_path}")" # use #W for application instead of directory
+  fill="$(get_tmux_option "@catppuccin_window_default_fill" "number")"                 # number, all, none
+
+  default_window_format=$(build_window_format "$number" "$color" "$background" "$text" "$fill")
 
   echo "$default_window_format"
 }


### PR DESCRIPTION
Todo:
- [x] ./catppuccin.tmux
- [x] Modules
  - [x] ./pane
  - [x] ./status
  - [x] ./window
- [x] Update workflow to check warnings

local command used: `shellcheck -a catppuccin.tmux $(ls custom/*.sh pane/*.sh status/*.sh window/*.sh)`