### PR TITLE
fixup! Cleanup shellcheck warnings (#178)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -26,5 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+        with:
+          additional_files: "catppuccin.tmux"
         env:
           SHELLCHECK_OPTS: "-a"


### PR DESCRIPTION
Don't remove checking for `catppuccin.tmux`