### PR TITLE
Respect `status_background` in `message-style`

### DIFF
--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -68,8 +68,18 @@ main() {
   set status-right-length "100"
 
   # messages
-  set message-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
-  set message-command-style "fg=${thm_cyan},bg=${thm_gray},align=centre"
+  local message_background
+  if [ "${status_background}" = "theme" ]; then
+    message_background="${thm_gray}"
+  else
+    if [ "${status_background}" = "default" ]; then
+      message_background="default"
+    else
+      message_background="${status_background}"
+    fi
+  fi
+  set message-style "fg=${thm_cyan},bg=${message_background},align=centre"
+  set message-command-style "fg=${thm_cyan},bg=${message_background},align=centre"
 
   # panes
   local pane_border_status pane_border_style \

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -45,7 +45,7 @@ main() {
   done <"${PLUGIN_DIR}/catppuccin-${theme}.tmuxtheme"
 
   # status general
-  local status_default status_justify status_background
+  local status_default status_justify status_background message_background
   status_default=$(get_tmux_option "@catppuccin_status_default" "on")
   # shellcheck disable=SC2121
   set status "$status_default"
@@ -56,11 +56,14 @@ main() {
   status_background=$(get_tmux_option "@catppuccin_status_background" "theme")
   if [ "${status_background}" = "theme" ]; then
     set status-bg "${thm_bg}"
+    message_background="${thm_gray}"
   else
     if [ "${status_background}" = "default" ]; then
       set status-style bg=default
+      message_background="default"
     else
       set status-bg "${status_background}"
+      message_background="${status_background}"
     fi
   fi
 
@@ -68,16 +71,6 @@ main() {
   set status-right-length "100"
 
   # messages
-  local message_background
-  if [ "${status_background}" = "theme" ]; then
-    message_background="${thm_gray}"
-  else
-    if [ "${status_background}" = "default" ]; then
-      message_background="default"
-    else
-      message_background="${status_background}"
-    fi
-  fi
   set message-style "fg=${thm_cyan},bg=${message_background},align=centre"
   set message-command-style "fg=${thm_cyan},bg=${message_background},align=centre"
 


### PR DESCRIPTION
When using `default` for `@catppuccin_status_background`, it still keeps background color for `message-style`. You can see it when you type a command in `tmux`.

Current implementation (with `@catppuccin_status_background` `"default"`):

<img width="519" alt="Screenshot 2024-04-17 at 20 06 38" src="https://github.com/catppuccin/tmux/assets/37471864/c8966499-4193-405a-a701-cea9d467ab01">

<img width="519" alt="Screenshot 2024-04-17 at 20 06 58" src="https://github.com/catppuccin/tmux/assets/37471864/c39247f0-e714-4920-b188-9ab448a1f785">

Respecting `@catppuccin_status_background` (with `@catppuccin_status_background` `"default"`):

<img width="519" alt="Screenshot 2024-04-17 at 20 07 53" src="https://github.com/catppuccin/tmux/assets/37471864/2c584528-e288-4f72-b8da-01fde24638d1">

<img width="519" alt="Screenshot 2024-04-17 at 20 08 44" src="https://github.com/catppuccin/tmux/assets/37471864/af022595-b4ae-4ed8-91a2-ad302c18a22f">
