### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: Report your bugs with the theme here!
+labels: [bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue outlining your problem?
+      description: Please search to see if an issue already exists for your problem.
+      options:
+        - label: I have searched the existing issues and they do not solve my problem.
+          required: true
+  - type: textarea
+    attributes:
+      label: Describe your problem.
+      description: Also tell us, what do you expect to see?
+      placeholder: The battery charging icon is missing...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Paste your configuration.
+      description: Provide us with the contents of your `.tmux.conf` file.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Attach screenshots.
+      description: If applicable, attach screenshots which clearly highlight the issue.
+  - type: input
+    attributes:
+      label: What tmux version are you seeing the issue on?
+      description: "You can find your version by running `tmux -V`"
+      placeholder: tmux 3.3a
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Any additional comments?
+      description: Add any information that hasn't been covered in the previous sections!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: Ask A Question
     url: https://github.com/catppuccin/tmux/discussions/new?category=q-a
-    about: Need help in tweaking your Catppuccin tmux configuration? Ask questions in GitHub Discussions!
+    about: Need help tweaking your Catppuccin tmux configuration? Ask questions in GitHub Discussions!
+  - name: Show & Tell
+    url: https://github.com/catppuccin/tmux/discussions/new?category=show-and-tell
+    about: Want to showcase your customised Catppuccin tmux configuration? Show it off in GitHub Discussions!
   - name: Community Discord
     url: https://discord.com/servers/catppuccin-907385605422448742
     about: Chat to other community members!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask A Question
+    url: https://github.com/catppuccin/tmux/discussions/new?category=q-a
+    about: Need help in tweaking your Catppuccin tmux configuration? Ask questions in GitHub Discussions!
+  - name: Community Discord
+    url: https://discord.com/servers/catppuccin-907385605422448742
+    about: Chat to other community members!

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,18 @@
+name: Enhancement Issue
+description: Request improvements to the theme here!
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue outlining your improvement?
+      description: Please search to see if your improvement has already been raised as an issue.
+      options:
+        - label: I have searched the existing issues and my improvement has not been raised yet.
+          required: true
+  - type: textarea
+    attributes:
+      label: What would you like to see added and/or changed?
+      description: Make sure to mention why you think this is an improvement!
+      placeholder: I'd like to have an extra configuration option for...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/meta.yml
+++ b/.github/ISSUE_TEMPLATE/meta.yml
@@ -1,0 +1,18 @@
+name: Meta Issue
+description: Raise any issue regarding the repository here!
+labels: [meta]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue outlining your problem?
+      description: Please search to see if an issue already exists for your problem.
+      options:
+        - label: I have searched the existing issues and they do not solve my problem.
+          required: true
+  - type: textarea
+    attributes:
+      label: Describe your issue.
+      description: Bugs should be raised under a [Bug Report](https://github.com/catppuccin/tmux/issues/new?assignees=&labels=bug&template=bug.yml).
+      placeholder: The README is missing crucial information such as...
+    validations:
+      required: true


### PR DESCRIPTION
This PR adds some issue templates to improve the quality of issues raised, as well as introduce GitHub discussions for general questions and for people to show off their Catppuccin tmux configs.

Pressing the `New issue` button now presents the following UI:

![image](https://github.com/catppuccin/tmux/assets/58985301/a56e617e-f3c2-4d7a-9d70-99af381823c5)

Expand the dropdowns below to see how each issue template renders.

<details>
<summary>Bug Report</summary>
<img src="https://github.com/catppuccin/tmux/assets/58985301/24d72136-b50f-4d72-8765-d72c7dc11069">
</details>

<details>
<summary>Enhancement Issue</summary>
<img src="https://github.com/catppuccin/tmux/assets/58985301/afaf3541-ab51-4655-9455-4c65957356fb">
</details>

<details>
<summary>Meta Issue</summary>
<img src="https://github.com/catppuccin/tmux/assets/58985301/501a6de8-37c4-4a07-b39b-56381fe52e57">
</details>

`Ask A Question` and `Show & Tell` link off to GitHub discussions. I think it'll be good to add discussion templates for these categories but I'd regard that as out of scope here and should be implemented by another PR.

I've left the `Community Discord` link in because [catppuccin/nvim](https://github.com/catppuccin/nvim/issues/new/choose) and [catppuccin/jetbrains](https://github.com/catppuccin/jetbrains/issues/new/choose) have it.

<hr>

Closes #171 