### PR TITLE
chore(issue-templates): fix `show & tell` discussion link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/catppuccin/tmux/discussions/new?category=q-a
     about: Need help tweaking your Catppuccin tmux configuration? Ask questions in GitHub Discussions!
   - name: Show & Tell
-    url: https://github.com/catppuccin/tmux/discussions/new?category=show-and-tell
+    url: https://github.com/catppuccin/tmux/discussions/new?category=show-tell
     about: Want to showcase your customised Catppuccin tmux configuration? Show it off in GitHub Discussions!
   - name: Community Discord
     url: https://discord.com/servers/catppuccin-907385605422448742


### PR DESCRIPTION
I renamed the discussion category and forgot to update the link. This PR updates the link to be correct