### PR TITLE
feat(status): window specific separator config

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ Values:
 set -g @catppuccin_window_current_text "#{b:pane_current_path}" # use "#W" for application instead of directory
 ```
 
+#### Override the window current separators
+```sh
+set -g @catppuccin_window_current_left_separator ""
+set -g @catppuccin_window_current_middle_separator "█"
+set -g @catppuccin_window_current_right_separator ""
+```
 ### Pane
 
 #### Set the pane border style:

--- a/builder/window_builder.sh
+++ b/builder/window_builder.sh
@@ -9,6 +9,7 @@ build_window_format() {
   local background="$3"
   local text="$4"
   local fill="$5"
+  local window_type="$6"
 
   # NOTE: For backwards compatibility remove before 1.0.0 and update default for
   # `@catppuccin_window_status`
@@ -36,6 +37,18 @@ build_window_format() {
     local icon
     icon="$(build_window_icon)"
     text="$text$icon"
+  fi
+
+  if [ "$window_type" = "current" ]; then
+    add_tmux_batch_option "@catppuccin_window_current_left_separator"
+    add_tmux_batch_option "@catppuccin_window_current_middle_separator"
+    add_tmux_batch_option "@catppuccin_window_current_right_separator"
+
+    run_tmux_batch_commands
+
+    window_left_separator=$(get_tmux_batch_option "@catppuccin_window_current_left_separator" "$window_left_separator")
+    window_middle_separator=$(get_tmux_batch_option "@catppuccin_window_current_middle_separator" "$window_middle_separator")
+    window_right_separator=$(get_tmux_batch_option "@catppuccin_window_current_right_separator" "$window_right_separator")
   fi
 
   if [ "$fill" = "none" ]; then

--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -18,7 +18,7 @@ show_window_current_format() {
   text="$(get_tmux_batch_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   fill="$(get_tmux_batch_option "@catppuccin_window_current_fill" "number")"                 # number, all, none
 
-  current_window_format=$(build_window_format "$number" "$color" "$background" "$text" "$fill")
+  current_window_format=$(build_window_format "$number" "$color" "$background" "$text" "$fill" "current")
 
   echo "$current_window_format"
 }

--- a/window/window_default_format.sh
+++ b/window/window_default_format.sh
@@ -18,7 +18,7 @@ show_window_default_format() {
   text="$(get_tmux_batch_option "@catppuccin_window_default_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   fill="$(get_tmux_batch_option "@catppuccin_window_default_fill" "number")"                 # number, all, none
 
-  default_window_format=$(build_window_format "$number" "$color" "$background" "$text" "$fill")
+  default_window_format=$(build_window_format "$number" "$color" "$background" "$text" "$fill" "default")
 
   echo "$default_window_format"
 }


### PR DESCRIPTION
This pull request:

- [x] Add `window_type` to `build_window_format`
- [x] If current window  separator is configured it will override global configuration
- [x] Update README.md to reflect new available options


Allowed new configuration options:
```conf
# Current type window configuration. If set, it will override the global configuration
set -g @catppuccin_window_current_left_separator "█"
set -g @catppuccin_window_current_middle_separator " 󰿟 "
set -g @catppuccin_window_current_right_separator "█"
```

Fixes #197 