### PR TITLE
fix(status): support tmux-battery attached status icon

### DIFF
--- a/status/battery.sh
+++ b/status/battery.sh
@@ -18,6 +18,7 @@ show_battery() {
   tmux set-option -g @batt_icon_status_charging '󰂄'
   tmux set-option -g @batt_icon_status_discharging '󰂃'
   tmux set-option -g @batt_icon_status_unknown '󰂑'
+  tmux set-option -g @batt_icon_status_attached "󱈑"
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 


### PR DESCRIPTION
fix #188 .
Add new icon to overwrite tmux-battery attached status in order to be consistent with other icon styles.
According to [https://github.com/tmux-plugins/tmux-battery/pull/4](url),`attached` status used to alert user powerline c onnect fine but battery might be not charged.
tmux-battery attached icon is '⚠️ ',and new icon is like:
![image](https://github.com/catppuccin/tmux/assets/28720943/0f675ca9-458b-47a6-bc58-20f0c5769cb1)
Alert battery icon is used to express discharging,so i use this icon.