### PR TITLE
fix(window_builder): number position left

### DIFF
--- a/builder/window_builder.sh
+++ b/builder/window_builder.sh
@@ -48,11 +48,12 @@ build_window_format() {
   fi
 
   if [ "$fill" = "number" ]; then
+    local show_middle_separator
     local show_number="#[fg=$background,bg=$color]$number"
-    local show_middle_separator="#[fg=$color,bg=$background,nobold,nounderscore,noitalics]$window_middle_separator"
     local show_text="#[fg=$thm_fg,bg=$background]$text"
 
     if [ "$window_number_position" = "right" ]; then
+      show_middle_separator="#[fg=$color,bg=$background,nobold,nounderscore,noitalics]$window_middle_separator"
       if [ "$status_connect_separator" = "yes" ]; then
         local show_left_separator="#[fg=$background,bg=$thm_bg,nobold,nounderscore,noitalics]$window_left_separator"
         local show_right_separator="#[fg=$color,bg=$thm_bg]$window_right_separator"
@@ -65,6 +66,8 @@ build_window_format() {
     fi
 
     if [ "$window_number_position" = "left" ]; then
+      show_middle_separator="#[fg=$background,bg=$color,nobold,nounderscore,noitalics]$window_middle_separator"
+
       if [ "$status_connect_separator" = "yes" ]; then
         local show_right_separator="#[fg=$background,bg=$thm_bg,nobold,nounderscore,noitalics]$window_right_separator"
         local show_left_separator="#[fg=$color,bg=$thm_bg]$window_left_separator"


### PR DESCRIPTION
Middle separator color was inverted when number position left.

Before:
![Screenshot from 2024-05-09 18-56-26](https://github.com/catppuccin/tmux/assets/44153531/6cdf9d15-f55b-4c0b-9f7c-6621b364a607)

After:
![Screenshot from 2024-05-09 18-56-13](https://github.com/catppuccin/tmux/assets/44153531/ac19309f-7f46-4f40-aafb-88f06e11063a)
