### PR TITLE
fixup! Feat: interpolate colors (#208)

### DIFF
--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -33,6 +33,7 @@ main() {
   local theme
   local color_interpolation=()
   local color_values=()
+  local temp
   theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
@@ -47,8 +48,11 @@ main() {
     # '$val' stores the value.
     eval "local $key"="$val"
 
+    # TODO: Find a better way to strip the quotes from `$val`
+    temp="${val%\"}"
+    temp="${temp#\"}"
     color_interpolation+=("\#{$key}")
-    color_values+=("${val:1:-1}")
+    color_values+=("${temp}")
   done <"${PLUGIN_DIR}/themes/catppuccin_${theme}.tmuxtheme"
 
   # status general


### PR DESCRIPTION
macos bash version (3.2.57) does not support the `"${val:1:-1}"` syntax