### PR TITLE
Fix/test old bash

### DIFF
--- a/.github/scripts/test.bash
+++ b/.github/scripts/test.bash
@@ -59,7 +59,7 @@ main() {
     exit 1
   else
     echo "Running plugin: $plugin" >&2
-    output=$(tmux run-shell "$plugin" 2>&1)
+    output="$(tmux run-shell "$plugin" 2>&1)"
     exit_code="$?"
 
     check "$exit_code" "$output"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,16 +38,14 @@ jobs:
     name: "Old Bash"
     runs-on: ubuntu-latest
     container:
-      image: bash:3.2.57 # Bash version used by macos
+      image: bash:3.2.57-alpine3.19 # Bash version used by macos
     steps:
       - uses: actions/checkout@v4
       - name: Check Syntax is Valid
         shell: bash
         run: |
-          # No tmux available in this container
-          tmp="$(mktemp -d)"
-          touch "$tmp/tmux"
-          chmod +x "$tmp/tmux"
-          export PATH="$tmp:$PATH"
+          apk update
+          apk add tmux
           bash --version
+          tmux -V
           ./.github/scripts/test.bash ./catppuccin.tmux


### PR DESCRIPTION
Actually use tmux instead of bypassing it to test compatibility with old bash version 3.2.57.
This will prevent accidents like `color_values+=("${val:1:-1}")` in #208 from going unnoticed  before merging.

Closes #215 