### PR TITLE
Add suport for tmux-mode-indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h3 align="center">
-	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
-	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
-	Catppuccin for <a href="https://github.com/tmux/tmux">Tmux</a>
-	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
+ <img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
+ <img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
+ Catppuccin for <a href="https://github.com/tmux/tmux">Tmux</a>
+ <img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
 </h3>
 
 <p align="center">
@@ -28,9 +28,10 @@
    1. [Pane](#pane)
    1. [Customizing modules](#customizing-modules)
    1. [Battery module](#battery-module)
-   1. [CPU module](#CPU-module)
+   1. [CPU module](#cpu-module)
    1. [Weather modules](#weather-modules)
    1. [Load module](#load-module)
+   1. [Mode Indicator module](#mode-indicator-module)
 1. [Create a custom module](#create-a-custom-module)
 1. [Configuration Examples](#configuration-examples)
    1. [Config 1](#config-1)
@@ -90,50 +91,64 @@ options to your Tmux configuration.
 ### Window
 
 ### Set the window separator
+
 ```sh
 set -g @catppuccin_window_separator ""
 ```
 
-#### Set the window left separator:
+#### Set the window left separator
+
 ```sh
 set -g @catppuccin_window_left_separator "█"
 ```
 
-#### Set the window middle separator:
+#### Set the window middle separator
+
 ```sh
 set -g @catppuccin_window_middle_separator "█"
 ```
 
-#### Set the window right separator:
+#### Set the window right separator
+
 ```sh
 set -g @catppuccin_window_right_separator "█"
 ```
 
-#### Position the number:
+#### Position the number
+
 ```sh
 set -g @catppuccin_window_number_position "left"
 ```
+
 Values:
+
 - left - the number will be on the left part of the window
 - right - the number will be on the right part of the window
 
-#### Enable window status:
+#### Enable window status
+
 ```sh
 set -g @catppuccin_window_status_enable "no"
 ```
+
 Values:
+
 - yes - this will enable the window status part
 - no - this will disable the window status part
 
-#### Enable window status icons instead of text:
+#### Enable window status icons instead of text
+
 ```sh
 set -g @catppuccin_window_status_icon_enable "yes"
 ```
+
 Values:
+
 - yes - this will replace the windows status text with icons
 - no - this will keep the windows status in text format
 
 #### Override windows status icons
+
 ```sh
 set -g @catppuccin_icon_window_last "󰖰"
 set -g @catppuccin_icon_window_current "󰖯"
@@ -146,123 +161,150 @@ set -g @catppuccin_icon_window_bell "󰂞"
 
 ### Window default
 
-#### Set the window default color fill:
+#### Set the window default color fill
+
 ```sh
 set -g @catppuccin_window_default_fill "number"
 ```
+
 Values:
+
 - number - only the number of the window part will have color
 - all - the entire window part will have the same color
 - none - the entire window part will have no color
 
-#### Override the window default colors:
+#### Override the window default colors
+
 ```sh
 set -g @catppuccin_window_default_color "#{thm_blue}" # text color
 set -g @catppuccin_window_default_background "#{thm_gray}"
 ```
 
 Values:
+
 - color - a theme color (`#{thm_<color>}`) or hexadecimal color value
 
-#### Override the window default text:
+#### Override the window default text
+
 ```sh
 set -g @catppuccin_window_default_text "#{b:pane_current_path}" # use "#W" for application instead of directory
 ```
 
 ### Window current
 
-#### Set the window current color fill:
+#### Set the window current color fill
+
 ```sh
 set -g @catppuccin_window_current_fill "number"
 ```
+
 Values:
+
 - number - only the number of the window part will have color
 - all - the entire window part will have the same color
 - none - the entire window part will have no color
 
-#### Override the window current colors:
+#### Override the window current colors
+
 ```sh
 set -g @catppuccin_window_current_color "#{thm_orange}" # text color
 set -g @catppuccin_window_current_background "#{thm_bg}"
 ```
 
 Values:
+
 - color - a theme color (`#{thm_<color>}`) or a hexadecimal color value
 
-#### Override the window current text:
+#### Override the window current text
+
 ```sh
 set -g @catppuccin_window_current_text "#{b:pane_current_path}" # use "#W" for application instead of directory
 ```
 
 ### Pane
 
-#### Set the pane border style:
+#### Set the pane border style
 
 ```sh
 set -g @catppuccin_pane_border_style "fg=#{thm_gray}" # Use a value compatible with the standard tmux 'pane-border-style'
 ```
 
-#### Set the pane active border style:
+#### Set the pane active border style
 
 ```sh
 set -g @catppuccin_pane_active_border_style "fg=#{thm_orange}" # Use a value compatible with the standard tmux 'pane-border-active-style'
 ```
 
-
 ### Status
+
 #### Set the default status bar visibility
+
 ```sh
 set -g @catppuccin_status_default "on"
 
 ```
 
 #### Override the default status background color
+
 ```sh
 set -g @catppuccin_status_background "theme"
 ```
+
 This will overwrite the status bar background:
+
 - "theme" will use the color from the selected theme
 - "default" will make the status bar transparent
 - use hex color codes for other colors or a theme color (`#{thm_<color>}`)
 
-Note: you need to restart tmux for this to take effect: 
+Note: you need to restart tmux for this to take effect:
+
 ```sh
 tmux kill-server & tmux
 ```
 
-#### Set the status module left separator:
+#### Set the status module left separator
+
 ```sh
 set -g @catppuccin_status_left_separator ""
 ```
 
-#### Set the status module right separator:
+#### Set the status module right separator
+
 ```sh
 set -g @catppuccin_status_right_separator "█"
 ```
 
-#### Set the status connect separator:
+#### Set the status connect separator
+
 ```sh
 set -g @catppuccin_status_connect_separator "yes"
 ```
+
 Values:
+
 - yes - the background color of the separator will not blend in with the background color of tmux
 - no - the background color of the separator will blend in with the background color of tmux
 
+#### Set the status module color fill
 
-#### Set the status module color fill:
 ```sh
 set -g @catppuccin_status_fill "icon"
 ```
+
 Values:
+
 - icon - only the icon of the module will have color
 - all - the entire module will have the same color
 
-#### Set the status module justify value:
+#### Set the status module justify value
+
 ```sh
 set -g @catppuccin_status_justify "left"
 ```
+
 Values:
-- left 
+
+- left
 - centre - puts the window list in the relative centre of the available free space
 - right
 - absolute-centre - uses the centre of the entire horizontal space
@@ -285,13 +327,16 @@ set -g @catppuccin_pane_background_color "#{thm_orange}"
 ```
 
 #### Set the module list
+
 ```sh
 set -g @catppuccin_status_modules_right "application session"
 set -g @catppuccin_status_modules_left ""
 ```
+
 Provide a list of modules and the order in which you want them to appear in the status.
 
 Available modules:
+
 - application - display the current window running application
 - directory - display the basename of the current window path
 - session - display the number of tmux sessions running
@@ -306,26 +351,32 @@ Available modules:
 Every module (except the module "session") supports the following overrides:
 
 #### Override the specific module icon
+
 ```sh
 set -g @catppuccin_[module_name]_icon "icon"
 ```
 
 #### Override the specific module color
+
 ```sh
 set -g @catppuccin_[module_name]_color "color"
 ```
 
 #### Override the specific module text
+
 ```sh
 set -g @catppuccin_[module_name]_text "text"
 ```
 
 #### Removing a specific module option
+
 ```sh
 set -g @catppuccin_[module_name]_[option] "null"
 ```
+
 This is for the situation where you want to remove the icon from a module.
 Ex:
+
 ```sh
 set -g @catppuccin_date_time_icon "null"
 ```
@@ -333,13 +384,17 @@ set -g @catppuccin_date_time_icon "null"
 ### Battery module
 
 #### Requirements
+
 This module depends on [tmux-battery](https://github.com/tmux-plugins/tmux-battery/tree/master).
 
 #### Install
+
 The preferred way to install tmux-battery is using [TPM](https://github.com/tmux-plugins/tpm).
 
 #### Configure
+
 Load tmux-battery after you load catppuccin.
+
 ```sh
 set -g @plugin 'catppuccin/tmux'
 ...
@@ -347,6 +402,7 @@ set -g @plugin 'tmux-plugins/tmux-battery'
 ```
 
 Add the battery module to the status modules list.
+
 ```sh
 set -g @catppuccin_status_modules_right "... battery ..."
 ```
@@ -354,13 +410,17 @@ set -g @catppuccin_status_modules_right "... battery ..."
 ### CPU module
 
 #### Requirements
+
 This module depends on [tmux-cpu](https://github.com/tmux-plugins/tmux-cpu/tree/master).
 
 #### Install
+
 The preferred way to install tmux-cpu is using [TPM](https://github.com/tmux-plugins/tpm).
 
 #### Configure
+
 Load tmux-cpu after you load catppuccin.
+
 ```sh
 set -g @plugin 'catppuccin/tmux'
 ...
@@ -368,6 +428,7 @@ set -g @plugin 'tmux-plugins/tmux-cpu'
 ```
 
 Add the cpu module to the status modules list.
+
 ```sh
 set -g @catppuccin_status_modules_right "... cpu ..."
 ```
@@ -377,13 +438,17 @@ set -g @catppuccin_status_modules_right "... cpu ..."
 #### tmux-weather
 
 ##### Requirements
+
 This module depends on [tmux-weather](https://github.com/xamut/tmux-weather).
 
 ##### Install
+
 The preferred way to install tmux-weather is using [TPM](https://github.com/tmux-plugins/tpm).
 
 ##### Configure
+
 Load tmux-weather after you load catppuccin.
+
 ```sh
 set -g @plugin 'catppuccin/tmux'
 ...
@@ -391,6 +456,7 @@ set -g @plugin 'xamut/tmux-weather'
 ```
 
 Add the weather module to the status modules list.
+
 ```sh
 set -g @catppuccin_status_modules_right "... weather ..."
 ```
@@ -398,13 +464,17 @@ set -g @catppuccin_status_modules_right "... weather ..."
 #### tmux-clima
 
 ##### Requirements
+
 This module depends on [tmux-clima](https://github.com/vascomfnunes/tmux-clima).
 
 ##### Install
+
 The preferred way to install tmux-clima is using [TPM](https://github.com/tmux-plugins/tpm).
 
 ##### Configure
+
 Load tmux-clima after you load catppuccin.
+
 ```sh
 set -g @plugin 'catppuccin/tmux'
 ...
@@ -412,6 +482,7 @@ set -g @plugin 'vascomfnunes/tmux-clima'
 ```
 
 Add the weather module to the status modules list.
+
 ```sh
 set -g @catppuccin_status_modules_right "... clima ..."
 ```
@@ -419,13 +490,17 @@ set -g @catppuccin_status_modules_right "... clima ..."
 ### Load module
 
 #### Requirements
+
 This module depends on [tmux-loadavg](https://github.com/jamesoff/tmux-loadavg).
 
 #### Install
+
 The preferred way to install tmux-loadavg is using [TPM](https://github.com/tmux-plugins/tpm).
 
 #### Configure
+
 Load tmux-loadavg after you load catppuccin.
+
 ```sh
 set -g @plugin 'catppuccin/tmux'
 ...
@@ -433,29 +508,60 @@ set -g @plugin 'jamesoff/tmux-loadavg'
 ```
 
 Add the load module to the status modules list.
+
 ```sh
 set -g @catppuccin_status_modules_right "... load ..."
+```
+
+### Mode Indicator module
+
+#### Requirements
+
+This module depends on [tmux-mode-indicator](https://github.com/MunifTanjim/tmux-mode-indicator).
+
+#### Install
+
+The preferred way to install tmux-mode-indicator is using [TPM](https://github.com/tmux-plugins/tpm).
+
+#### Configure
+
+Load tmux-mode-indicator after you load catppuccin.
+
+```sh
+set -g @plugin 'catppuccin/tmux'
+...
+set -g @plugin 'MunifTanjim/tmux-mode-indicator'
+```
+
+Add the mode_indicator module to the status modules list.
+
+```sh
+set -g @catppuccin_status_modules_right "... mode_indicator ..."
 ```
 
 ### Gitmux module
 
 #### Requirements
+
 This module depends on [gitmux](https://github.com/arl/gitmux).
 
 #### Install
+
 To install gitmux, follow the instructions in the [gitmux documentation](https://github.com/arl/gitmux/blob/main/README.md#installing).
 
 #### Configure
+
 Add the gitmux module to the status modules list.
+
 ```sh
 set -g @catppuccin_status_modules_right "... gitmux ..."
 ```
 
 To customize the gitmux module, you can follow the instrucctions in the [gitmux documentation](https://github.com/arl/gitmux/blob/main/README.md#customizing) and add this line in your tmux configuration:
+
 ```sh
 set -g @catppuccin_gitmux_text "#(gitmux -cfg $HOME/.gitmux.conf \"#{pane_current_path}\")"
 ```
-
 
 ## Create a custom module
 
@@ -466,17 +572,20 @@ For further details, see the documentation in [custom/README.md](custom/README.m
 Any file added to the custom folder will be preserved when updating catppuccin.
 
 ## Configuration Examples
+
 Below are provided a few configurations as examples or starting points.
 
 Note:
 When switching between configurations run:
+
 ```sh
 tmux kill-server
 ```
+
 To kill the tmux server and clear all global variables.
 
-
 ### Config 1
+
 ![Default](./assets/config1.png)
 
 ```sh
@@ -496,6 +605,7 @@ set -g @catppuccin_date_time_text "%Y-%m-%d %H:%M:%S"
 ```
 
 ### Config 2
+
 ![Default](./assets/config2.png)
 
 ```sh
@@ -517,6 +627,7 @@ set -g @catppuccin_status_connect_separator "yes"
 ```
 
 ### Config 3
+
 ![Default](./assets/config3.png)
 
 ```sh
@@ -553,4 +664,3 @@ set -g @catppuccin_directory_text "#{pane_current_path}"
 <p align="center"><img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/footers/gray0_ctp_on_line.svg?sanitize=true" /></p>
 <p align="center">Copyright &copy; 2021-present <a href="https://github.com/catppuccin" target="_blank">Catppuccin Org</a>
 <p align="center"><a href="https://github.com/catppuccin/catppuccin/blob/main/LICENSE"><img src="https://img.shields.io/static/v1.svg?style=for-the-badge&label=License&message=MIT&logoColor=d9e0ee&colorA=363a4f&colorB=b7bdf8"/></a></p>
-

--- a/status/mode_indicator.sh
+++ b/status/mode_indicator.sh
@@ -1,0 +1,27 @@
+# Requires https://github.com/MunifTanjim/tmux-mode-indicator
+
+show_mode_indicator() {
+  local index icon color text module
+
+  index=$1
+
+  icon="$(get_tmux_option "@catppuccin_mode_indicator_icon" "")"
+  color="$(get_tmux_option "@catppuccin_mode_indicator_color" "$thm_teal")"
+  text="$(get_tmux_option "@catppuccin_mode_indicator_text" "#{tmux_mode_indicator}")"
+
+  # Choose to Keep colour constant and only change text
+  set -g @mode_indicator_prefix_mode_style "bg=$color,fg=black"
+  set -g @mode_indicator_copy_mode_style "bg=$color,fg=black"
+  set -g @mode_indicator_sync_mode_style "bg=$color,fg=black"
+  set -g @mode_indicator_empty_mode_style "bg=$color,fg=black"
+
+  # Displaying TMUX in normal mode is confusing, so let's make it more sensible
+  set -g @mode_indicator_empty_prompt '----'
+  set -g @mode_indicator_prefix_prompt 'WAIT'
+  set -g @mode_indicator_copy_prompt 'COPY'
+  set -g @mode_indicator_sync_prompt 'SYNC'
+
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
+
+  echo "$module"
+}

--- a/status/mode_indicator.sh
+++ b/status/mode_indicator.sh
@@ -6,20 +6,20 @@ show_mode_indicator() {
   index=$1
 
   icon="$(get_tmux_option "@catppuccin_mode_indicator_icon" "")"
-  color="$(get_tmux_option "@catppuccin_mode_indicator_color" "$thm_teal")"
+  color="$(get_tmux_option "@catppuccin_mode_indicator_color" "$thm_yellow")"
   text="$(get_tmux_option "@catppuccin_mode_indicator_text" "#{tmux_mode_indicator}")"
 
   # Choose to Keep colour constant and only change text
-  set -g @mode_indicator_prefix_mode_style "bg=$color,fg=black"
-  set -g @mode_indicator_copy_mode_style "bg=$color,fg=black"
-  set -g @mode_indicator_sync_mode_style "bg=$color,fg=black"
-  set -g @mode_indicator_empty_mode_style "bg=$color,fg=black"
+  tmux set -g @mode_indicator_prefix_mode_style "bg=$color,fg=black"
+  tmux set -g @mode_indicator_copy_mode_style "bg=$color,fg=black"
+  tmux set -g @mode_indicator_sync_mode_style "bg=$color,fg=black"
+  tmux set -g @mode_indicator_empty_mode_style "bg=$color,fg=black"
 
   # Displaying TMUX in normal mode is confusing, so let's make it more sensible
-  set -g @mode_indicator_empty_prompt '----'
-  set -g @mode_indicator_prefix_prompt 'WAIT'
-  set -g @mode_indicator_copy_prompt 'COPY'
-  set -g @mode_indicator_sync_prompt 'SYNC'
+  tmux set -g @mode_indicator_empty_prompt '----'
+  tmux set -g @mode_indicator_prefix_prompt 'WAIT'
+  tmux set -g @mode_indicator_copy_prompt 'COPY'
+  tmux set -g @mode_indicator_sync_prompt 'SYNC'
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 


### PR DESCRIPTION
Adds support for [tmux-mode-indicator](https://github.com/MunifTanjim/tmux-mode-indicator).
Classically, this plugin changes its background colour by mode. There is no single
`bg` setting in the plugin, but rather a separate one for each mode. To make the
catppuccin `bg` change dynamically as well, we would then need to re-implement the
logic for detecting the mode. To avoid this complexity, this PR sets all the
`bg` colours to the catppuccin background colour and only changes the text.
