### PR TITLE
perf: batch tmux show-options

### DIFF
--- a/builder/window_builder.sh
+++ b/builder/window_builder.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+
+show_window_status=
+
 build_window_format() {
   local number="$1"
   local color="$2"
@@ -93,34 +96,56 @@ build_window_format() {
 }
 
 build_window_icon() {
-  local window_status_icon_enable custom_icon_window_last \
-    custom_icon_window_zoom custom_icon_window_mark custom_icon_window_mark \
-    custom_icon_window_silent custom_icon_window_activity custom_icon_window_bell
+  # Only update `show_window_status` if it's not empty
+  # this module is ran twice once for current and once for default
+  # meaning 2 calls to build_window_icon wich will/should both return the same
+  # result.
+  if [ -z "$show_window_status" ]; then
+    local window_status_icon_enable custom_icon_window_last \
+      custom_icon_window_zoom custom_icon_window_mark custom_icon_window_mark \
+      custom_icon_window_silent custom_icon_window_activity custom_icon_window_bell
 
-  window_status_icon_enable=$(get_tmux_option "@catppuccin_window_status_icon_enable" "yes")
-  custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰")
-  custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯")
-  custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌")
-  custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀")
-  custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛")
-  custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫")
-  custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞")
+    # shellcheck disable=SC2034
+    local tmux_batch_options_commands=()
+    # shellcheck disable=SC2034
+    local tmux_batch_options=()
 
-  if [ "$window_status_icon_enable" = "yes" ]; then
-    # #!~[*-]MZ
-    local show_window_status=""
-    show_window_status+="#{?window_activity_flag, ${custom_icon_window_activity},}"
-    show_window_status+="#{?window_bell_flag, ${custom_icon_window_bell},}"
-    show_window_status+="#{?window_silence_flag, ${custom_icon_window_silent},}"
-    show_window_status+="#{?window_active, ${custom_icon_window_current},}"
-    show_window_status+="#{?window_last_flag, ${custom_icon_window_last},}"
-    show_window_status+="#{?window_marked_flag, ${custom_icon_window_mark},}"
-    show_window_status+="#{?window_zoomed_flag, ${custom_icon_window_zoom},}"
+    add_tmux_batch_option "@catppuccin_window_status_icon_enable"
+    add_tmux_batch_option "@catppuccin_icon_window_last"
+    add_tmux_batch_option "@catppuccin_icon_window_current"
+    add_tmux_batch_option "@catppuccin_icon_window_zoom"
+    add_tmux_batch_option "@catppuccin_icon_window_mark"
+    add_tmux_batch_option "@catppuccin_icon_window_silent"
+    add_tmux_batch_option "@catppuccin_icon_window_activity"
+    add_tmux_batch_option "@catppuccin_icon_window_bell"
 
-  fi
+    run_tmux_batch_commands
 
-  if [ "$window_status_icon_enable" = "no" ]; then
-    local show_window_status=" #F"
+    window_status_icon_enable=$(get_tmux_batch_option "@catppuccin_window_status_icon_enable" "yes")
+    custom_icon_window_last=$(get_tmux_batch_option "@catppuccin_icon_window_last" "󰖰")
+    custom_icon_window_current=$(get_tmux_batch_option "@catppuccin_icon_window_current" "󰖯")
+    custom_icon_window_zoom=$(get_tmux_batch_option "@catppuccin_icon_window_zoom" "󰁌")
+    custom_icon_window_mark=$(get_tmux_batch_option "@catppuccin_icon_window_mark" "󰃀")
+    custom_icon_window_silent=$(get_tmux_batch_option "@catppuccin_icon_window_silent" "󰂛")
+    custom_icon_window_activity=$(get_tmux_batch_option "@catppuccin_icon_window_activity" "󱅫")
+    custom_icon_window_bell=$(get_tmux_batch_option "@catppuccin_icon_window_bell" "󰂞")
+
+    if [ "$window_status_icon_enable" = "yes" ]; then
+      # #!~[*-]MZ
+      show_window_status=""
+      show_window_status+="#{?window_activity_flag, ${custom_icon_window_activity},}"
+      show_window_status+="#{?window_bell_flag, ${custom_icon_window_bell},}"
+      show_window_status+="#{?window_silence_flag, ${custom_icon_window_silent},}"
+      show_window_status+="#{?window_active, ${custom_icon_window_current},}"
+      show_window_status+="#{?window_last_flag, ${custom_icon_window_last},}"
+      show_window_status+="#{?window_marked_flag, ${custom_icon_window_mark},}"
+      show_window_status+="#{?window_zoomed_flag, ${custom_icon_window_zoom},}"
+
+    fi
+
+    if [ "$window_status_icon_enable" = "no" ]; then
+      show_window_status=" #F"
+    fi
   fi
 
   echo "$show_window_status"

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -88,22 +88,6 @@ main() {
   add_tmux_batch_option "@catppuccin_status_modules_left"
   add_tmux_batch_option "@catppuccin_status_modules_right"
 
-  # Module options that are _always_ required
-  add_tmux_batch_option "@catppuccin_pane_color"
-  add_tmux_batch_option "@catppuccin_pane_background_color"
-  add_tmux_batch_option "@catppuccin_pane_default_text"
-  add_tmux_batch_option "@catppuccin_pane_default_fill"
-
-  add_tmux_batch_option "@catppuccin_window_default_color"
-  add_tmux_batch_option "@catppuccin_window_default_background"
-  add_tmux_batch_option "@catppuccin_window_default_text"
-  add_tmux_batch_option "@catppuccin_window_default_fill"
-
-  add_tmux_batch_option "@catppuccin_window_current_color"
-  add_tmux_batch_option "@catppuccin_window_current_background"
-  add_tmux_batch_option "@catppuccin_window_current_text"
-  add_tmux_batch_option "@catppuccin_window_current_fill"
-
   run_tmux_batch_commands
 
   # status general

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -21,9 +21,19 @@ main() {
   # Aggregate all commands in one array
   local tmux_commands=()
 
+  # Aggregate all tmux option for tmux_batch_option
+  local tmux_batch_options_commands=()
+  local tmux_batch_options=()
+
+  # Batch options for loading the colorscheme and everyting before
+  add_tmux_batch_option "@catppuccin_custom_plugin_dir"
+  add_tmux_batch_option "@catppuccin_flavour"
+
+  run_tmux_batch_commands
+
   # module directories
   local custom_path modules_custom_path modules_status_path modules_window_path modules_pane_path
-  custom_path="$(get_tmux_option "@catppuccin_custom_plugin_dir" "${PLUGIN_DIR}/custom")"
+  custom_path="$(get_tmux_batch_option "@catppuccin_custom_plugin_dir" "${PLUGIN_DIR}/custom")"
   modules_custom_path=$custom_path
   modules_status_path=$PLUGIN_DIR/status
   modules_window_path=$PLUGIN_DIR/window
@@ -34,7 +44,7 @@ main() {
   local color_interpolation=()
   local color_values=()
   local temp
-  theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
+  theme="$(get_tmux_batch_option "@catppuccin_flavour" "mocha")"
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
   # https://github.com/dylanaraps/pure-sh-bible#parsing-a-keyval-file
@@ -55,16 +65,57 @@ main() {
     color_values+=("${temp}")
   done <"${PLUGIN_DIR}/themes/catppuccin_${theme}.tmuxtheme"
 
+  # Batch options for `./catppuccin.tmux`
+  add_tmux_batch_option "@catppuccin_status_default"
+  add_tmux_batch_option "@catppuccin_status_justify"
+  add_tmux_batch_option "@catppuccin_status_background"
+  add_tmux_batch_option "@catppuccin_pane_status_enabled"
+  add_tmux_batch_option "@catppuccin_pane_border_status"
+  add_tmux_batch_option "@catppuccin_pane_left_separator"
+  add_tmux_batch_option "@catppuccin_pane_middle_separator"
+  add_tmux_batch_option "@catppuccin_pane_right_separator"
+  add_tmux_batch_option "@catppuccin_pane_number_position"
+  add_tmux_batch_option "@catppuccin_window_separator"
+  add_tmux_batch_option "@catppuccin_window_left_separator"
+  add_tmux_batch_option "@catppuccin_window_right_separator"
+  add_tmux_batch_option "@catppuccin_window_middle_separator"
+  add_tmux_batch_option "@catppuccin_window_number_position"
+  add_tmux_batch_option "@catppuccin_window_status_enable"
+  add_tmux_batch_option "@catppuccin_status_left_separator"
+  add_tmux_batch_option "@catppuccin_status_right_separator"
+  add_tmux_batch_option "@catppuccin_status_connect_separator"
+  add_tmux_batch_option "@catppuccin_status_fill"
+  add_tmux_batch_option "@catppuccin_status_modules_left"
+  add_tmux_batch_option "@catppuccin_status_modules_right"
+
+  # Module options that are _always_ required
+  add_tmux_batch_option "@catppuccin_pane_color"
+  add_tmux_batch_option "@catppuccin_pane_background_color"
+  add_tmux_batch_option "@catppuccin_pane_default_text"
+  add_tmux_batch_option "@catppuccin_pane_default_fill"
+
+  add_tmux_batch_option "@catppuccin_window_default_color"
+  add_tmux_batch_option "@catppuccin_window_default_background"
+  add_tmux_batch_option "@catppuccin_window_default_text"
+  add_tmux_batch_option "@catppuccin_window_default_fill"
+
+  add_tmux_batch_option "@catppuccin_window_current_color"
+  add_tmux_batch_option "@catppuccin_window_current_background"
+  add_tmux_batch_option "@catppuccin_window_current_text"
+  add_tmux_batch_option "@catppuccin_window_current_fill"
+
+  run_tmux_batch_commands
+
   # status general
   local status_default status_justify status_background message_background
-  status_default=$(get_tmux_option "@catppuccin_status_default" "on")
+  status_default=$(get_tmux_batch_option "@catppuccin_status_default" "on")
   # shellcheck disable=SC2121
   set status "$status_default"
 
-  status_justify=$(get_tmux_option "@catppuccin_status_justify" "left")
+  status_justify=$(get_tmux_batch_option "@catppuccin_status_justify" "left")
   set status-justify "$status_justify"
 
-  status_background=$(get_tmux_option "@catppuccin_status_background" "theme")
+  status_background=$(get_tmux_batch_option "@catppuccin_status_background" "theme")
   if [ "${status_background}" = "theme" ]; then
     set status-bg "${thm_bg}"
     message_background="${thm_gray}"
@@ -98,19 +149,19 @@ main() {
   local pane_border_status pane_border_style \
     pane_active_border_style pane_left_separator pane_middle_separator \
     pane_right_separator pane_number_position pane_format
-  pane_status_enable=$(get_tmux_option "@catppuccin_pane_status_enabled" "no") # yes
-  pane_border_status=$(get_tmux_option "@catppuccin_pane_border_status" "off") # bottom
+  pane_status_enable=$(get_tmux_batch_option "@catppuccin_pane_status_enabled" "no") # yes
+  pane_border_status=$(get_tmux_batch_option "@catppuccin_pane_border_status" "off") # bottom
   pane_border_style=$(
-    get_interpolated_tmux_option "@catppuccin_pane_border_style" "fg=${thm_gray}"
+    get_interpolated_tmux_batch_option "@catppuccin_pane_border_style" "fg=${thm_gray}"
   )
   pane_active_border_style=$(
-    get_interpolated_tmux_option "@catppuccin_pane_active_border_style" \
+    get_interpolated_tmux_batch_option "@catppuccin_pane_active_border_style" \
       "#{?pane_in_mode,fg=${thm_yellow},#{?pane_synchronized,fg=${thm_magenta},fg=${thm_orange}}}"
   )
-  pane_left_separator=$(get_tmux_option "@catppuccin_pane_left_separator" "█")
-  pane_middle_separator=$(get_tmux_option "@catppuccin_pane_middle_separator" "█")
-  pane_right_separator=$(get_tmux_option "@catppuccin_pane_right_separator" "█")
-  pane_number_position=$(get_tmux_option "@catppuccin_pane_number_position" "left") # right, left
+  pane_left_separator=$(get_tmux_batch_option "@catppuccin_pane_left_separator" "█")
+  pane_middle_separator=$(get_tmux_batch_option "@catppuccin_pane_middle_separator" "█")
+  pane_right_separator=$(get_tmux_batch_option "@catppuccin_pane_right_separator" "█")
+  pane_number_position=$(get_tmux_batch_option "@catppuccin_pane_number_position" "left") # right, left
   pane_format=$(load_modules "pane_default_format" "$modules_custom_path" "$modules_pane_path")
 
   setw pane-border-status "$pane_border_status"
@@ -123,14 +174,14 @@ main() {
     window_middle_separator window_number_position window_status_enable \
     window_format window_current_format
 
-  window_status_separator=$(get_interpolated_tmux_option "@catppuccin_window_separator" "")
+  window_status_separator=$(get_interpolated_tmux_batch_option "@catppuccin_window_separator" "")
   setw window-status-separator "$window_status_separator"
 
-  window_left_separator=$(get_tmux_option "@catppuccin_window_left_separator" "█")
-  window_right_separator=$(get_tmux_option "@catppuccin_window_right_separator" "█")
-  window_middle_separator=$(get_tmux_option "@catppuccin_window_middle_separator" "█ ")
-  window_number_position=$(get_tmux_option "@catppuccin_window_number_position" "left") # right, left
-  window_status_enable=$(get_tmux_option "@catppuccin_window_status_enable" "no")       # right, left
+  window_left_separator=$(get_tmux_batch_option "@catppuccin_window_left_separator" "█")
+  window_right_separator=$(get_tmux_batch_option "@catppuccin_window_right_separator" "█")
+  window_middle_separator=$(get_tmux_batch_option "@catppuccin_window_middle_separator" "█ ")
+  window_number_position=$(get_tmux_batch_option "@catppuccin_window_number_position" "left") # right, left
+  window_status_enable=$(get_tmux_batch_option "@catppuccin_window_status_enable" "no")       # right, left
 
   window_format=$(load_modules "window_default_format" "$modules_custom_path" "$modules_window_path")
   setw window-status-format "$(do_color_interpolation "$window_format")"
@@ -141,16 +192,16 @@ main() {
   # status module
   local status_left_separator status_right_separator status_connect_separator \
     status_fill status_modules_left status_modules_right
-  status_left_separator=$(get_tmux_option "@catppuccin_status_left_separator" "")
-  status_right_separator=$(get_tmux_option "@catppuccin_status_right_separator" "█")
-  status_connect_separator=$(get_tmux_option "@catppuccin_status_connect_separator" "yes")
-  status_fill=$(get_tmux_option "@catppuccin_status_fill" "icon")
+  status_left_separator=$(get_tmux_batch_option "@catppuccin_status_left_separator" "")
+  status_right_separator=$(get_tmux_batch_option "@catppuccin_status_right_separator" "█")
+  status_connect_separator=$(get_tmux_batch_option "@catppuccin_status_connect_separator" "yes")
+  status_fill=$(get_tmux_batch_option "@catppuccin_status_fill" "icon")
 
-  status_modules_left=$(get_tmux_option "@catppuccin_status_modules_left" "")
+  status_modules_left=$(get_tmux_batch_option "@catppuccin_status_modules_left" "")
   loaded_modules_left=$(load_modules "$status_modules_left" "$modules_custom_path" "$modules_status_path")
   set status-left "$(do_color_interpolation "$loaded_modules_left")"
 
-  status_modules_right=$(get_tmux_option "@catppuccin_status_modules_right" "application session")
+  status_modules_right=$(get_tmux_batch_option "@catppuccin_status_modules_right" "application session")
   loaded_modules_right=$(load_modules "$status_modules_right" "$modules_custom_path" "$modules_status_path")
   set status-right "$(do_color_interpolation "$loaded_modules_right")"
 

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -69,6 +69,9 @@ main() {
   add_tmux_batch_option "@catppuccin_status_default"
   add_tmux_batch_option "@catppuccin_status_justify"
   add_tmux_batch_option "@catppuccin_status_background"
+  add_tmux_batch_option "@catppuccin_menu_style"
+  add_tmux_batch_option "@catppuccin_menu_selected_style"
+  add_tmux_batch_option "@catppuccin_menu_border_style"
   add_tmux_batch_option "@catppuccin_pane_status_enabled"
   add_tmux_batch_option "@catppuccin_pane_border_status"
   add_tmux_batch_option "@catppuccin_pane_left_separator"
@@ -122,9 +125,9 @@ main() {
 
   # menu
   local menu_style menu_selected_style menu_border_style
-  menu_style=$(get_interpolated_tmux_option "@catppuccin_menu_style" "default")
-  menu_selected_style=$(get_interpolated_tmux_option "@catppuccin_menu_selected_style" "fg=${thm_gray},bg=${thm_yellow}")
-  menu_border_style=$(get_interpolated_tmux_option "@catppuccin_menu_border_style" "default")
+  menu_style=$(get_interpolated_tmux_batch_option "@catppuccin_menu_style" "default")
+  menu_selected_style=$(get_interpolated_tmux_batch_option "@catppuccin_menu_selected_style" "fg=${thm_gray},bg=${thm_yellow}")
+  menu_border_style=$(get_interpolated_tmux_batch_option "@catppuccin_menu_border_style" "default")
   set menu-style "$menu_style"
   set menu-selected-style "$menu_selected_style"
   set menu-border-style "$menu_border_style"

--- a/pane/pane_default_format.sh
+++ b/pane/pane_default_format.sh
@@ -1,5 +1,16 @@
 show_pane_default_format() {
   local number color background text fill
+  # shellcheck disable=SC2034
+  local tmux_batch_options_commands=()
+  # shellcheck disable=SC2034
+  local tmux_batch_options=()
+
+  add_tmux_batch_option "@catppuccin_pane_color"
+  add_tmux_batch_option "@catppuccin_pane_background_color"
+  add_tmux_batch_option "@catppuccin_pane_default_text"
+  add_tmux_batch_option "@catppuccin_pane_default_fill"
+
+  run_tmux_batch_commands
 
   number="#{pane_index}"
   color="$(get_tmux_batch_option "@catppuccin_pane_color" "$thm_green")"

--- a/pane/pane_default_format.sh
+++ b/pane/pane_default_format.sh
@@ -2,10 +2,10 @@ show_pane_default_format() {
   local number color background text fill
 
   number="#{pane_index}"
-  color="$(get_tmux_option "@catppuccin_pane_color" "$thm_green")"
-  background="$(get_tmux_option "@catppuccin_pane_background_color" "$thm_gray")"
-  text="$(get_tmux_option "@catppuccin_pane_default_text" "#{b:pane_current_path}")"
-  fill="$(get_tmux_option "@catppuccin_pane_default_fill" "number")" # number, all, none
+  color="$(get_tmux_batch_option "@catppuccin_pane_color" "$thm_green")"
+  background="$(get_tmux_batch_option "@catppuccin_pane_background_color" "$thm_gray")"
+  text="$(get_tmux_batch_option "@catppuccin_pane_default_text" "#{b:pane_current_path}")"
+  fill="$(get_tmux_batch_option "@catppuccin_pane_default_fill" "number")" # number, all, none
 
   default_pane_format=$(build_pane_format "$number" "$color" "$background" "$text" "$fill")
 

--- a/status/application.sh
+++ b/status/application.sh
@@ -1,7 +1,7 @@
 show_application() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_status_module "application"
   run_tmux_batch_commands
 
   index=$1

--- a/status/application.sh
+++ b/status/application.sh
@@ -1,10 +1,13 @@
 show_application() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon=$(get_tmux_option "@catppuccin_application_icon" "")
-  color=$(get_tmux_option "@catppuccin_application_color" "$thm_pink")
-  text=$(get_tmux_option "@catppuccin_application_text" "#{pane_current_command}")
+  icon=$(get_tmux_batch_option "@catppuccin_application_icon" "")
+  color=$(get_tmux_batch_option "@catppuccin_application_color" "$thm_pink")
+  text=$(get_tmux_batch_option "@catppuccin_application_text" "#{pane_current_command}")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/battery.sh
+++ b/status/battery.sh
@@ -1,24 +1,28 @@
 show_battery() {
   local index icon color text module
 
-  index=$1
-  icon=$(get_tmux_option "@catppuccin_battery_icon" "#{battery_icon}")
-  color=$(get_tmux_option "@catppuccin_battery_color" "$thm_yellow")
-  text=$(get_tmux_option "@catppuccin_battery_text" "#{battery_percentage}")
+  tmux_batch_setup_module "application"
 
-  tmux set-option -g @batt_icon_charge_tier8 '󰁹'
-  tmux set-option -g @batt_icon_charge_tier7 '󰂁'
-  tmux set-option -g @batt_icon_charge_tier6 '󰁿'
-  tmux set-option -g @batt_icon_charge_tier5 '󰁾'
-  tmux set-option -g @batt_icon_charge_tier4 '󰁽'
-  tmux set-option -g @batt_icon_charge_tier3 '󰁼'
-  tmux set-option -g @batt_icon_charge_tier2 '󰁻'
-  tmux set-option -g @batt_icon_charge_tier1 '󰁺'
-  tmux set-option -g @batt_icon_status_charged '󰚥'
-  tmux set-option -g @batt_icon_status_charging '󰂄'
-  tmux set-option -g @batt_icon_status_discharging '󰂃'
-  tmux set-option -g @batt_icon_status_unknown '󰂑'
-  tmux set-option -g @batt_icon_status_attached "󱈑"
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier8 󰁹 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier7 󰂁 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier6 󰁿 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier5 󰁾 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier4 󰁽 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier3 󰁼 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier2 󰁻 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier1 󰁺 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_status_charged 󰚥 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_status_charging 󰂄 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_status_discharging 󰂃 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_status_unknown 󰂑 ;")
+  tmux_batch_options_commands+=("set-option -gq @batt_icon_status_attached 󱈑 ;")
+
+  run_tmux_batch_commands
+
+  index=$1
+  icon=$(get_tmux_batch_option "@catppuccin_battery_icon" "#{battery_icon}")
+  color=$(get_tmux_batch_option "@catppuccin_battery_color" "$thm_yellow")
+  text=$(get_tmux_batch_option "@catppuccin_battery_text" "#{battery_percentage}")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/battery.sh
+++ b/status/battery.sh
@@ -1,7 +1,7 @@
 show_battery() {
   local index icon color text module
 
-  tmux_batch_setup_module "battery"
+  tmux_batch_setup_status_module "battery"
 
   tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier8 󰁹 ;")
   tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier7 󰂁 ;")

--- a/status/battery.sh
+++ b/status/battery.sh
@@ -1,7 +1,7 @@
 show_battery() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "battery"
 
   tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier8 󰁹 ;")
   tmux_batch_options_commands+=("set-option -gq @batt_icon_charge_tier7 󰂁 ;")

--- a/status/clima.sh
+++ b/status/clima.sh
@@ -2,10 +2,13 @@
 show_clima() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon="$(get_tmux_option "@catppuccin_clima_icon" "")"
-  color="$(get_tmux_option "@catppuccin_clima_color" "$thm_yellow")"
-  text="$(get_tmux_option "@catppuccin_clima_text" "#{clima}")"
+  icon="$(get_tmux_batch_option "@catppuccin_clima_icon" "")"
+  color="$(get_tmux_batch_option "@catppuccin_clima_color" "$thm_yellow")"
+  text="$(get_tmux_batch_option "@catppuccin_clima_text" "#{clima}")"
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/clima.sh
+++ b/status/clima.sh
@@ -2,7 +2,7 @@
 show_clima() {
   local index icon color text module
 
-  tmux_batch_setup_module "clima"
+  tmux_batch_setup_status_module "clima"
   run_tmux_batch_commands
 
   index=$1

--- a/status/clima.sh
+++ b/status/clima.sh
@@ -2,7 +2,7 @@
 show_clima() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "clima"
   run_tmux_batch_commands
 
   index=$1

--- a/status/cpu.sh
+++ b/status/cpu.sh
@@ -1,14 +1,18 @@
 show_cpu() {
   local index icon color text module
 
-  index=$1
-  icon=$(get_tmux_option "@catppuccin_cpu_icon" "")
-  color="$(get_tmux_option "@catppuccin_cpu_color" "#{cpu_bg_color}")"
-  text="$(get_tmux_option "@catppuccin_cpu_text" "#{cpu_percentage}")"
+  tmux_batch_setup_module "application"
 
-  tmux set-option -g @cpu_low_bg_color "$thm_yellow"    # background color when cpu is low
-  tmux set-option -g @cpu_medium_bg_color "$thm_orange" # background color when cpu is medium
-  tmux set-option -g @cpu_high_bg_color "$thm_red"      # background color when cpu is high
+  tmux_batch_options_commands+=("set-option -gq @cpu_low_bg_color $thm_yellow ;")    # background color when cpu is low
+  tmux_batch_options_commands+=("set-option -gq @cpu_medium_bg_color $thm_orange ;") # background color when cpu is medium
+  tmux_batch_options_commands+=("set-option -gq @cpu_high_bg_color $thm_red ;")      # background color when cpu is high
+
+  run_tmux_batch_commands
+
+  index=$1
+  icon=$(get_tmux_batch_option "@catppuccin_cpu_icon" "")
+  color="$(get_tmux_batch_option "@catppuccin_cpu_color" "#{cpu_bg_color}")"
+  text="$(get_tmux_batch_option "@catppuccin_cpu_text" "#{cpu_percentage}")"
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/cpu.sh
+++ b/status/cpu.sh
@@ -1,7 +1,7 @@
 show_cpu() {
   local index icon color text module
 
-  tmux_batch_setup_module "cpu"
+  tmux_batch_setup_status_module "cpu"
 
   tmux_batch_options_commands+=("set-option -gq @cpu_low_bg_color $thm_yellow ;")    # background color when cpu is low
   tmux_batch_options_commands+=("set-option -gq @cpu_medium_bg_color $thm_orange ;") # background color when cpu is medium

--- a/status/cpu.sh
+++ b/status/cpu.sh
@@ -1,7 +1,7 @@
 show_cpu() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "cpu"
 
   tmux_batch_options_commands+=("set-option -gq @cpu_low_bg_color $thm_yellow ;")    # background color when cpu is low
   tmux_batch_options_commands+=("set-option -gq @cpu_medium_bg_color $thm_orange ;") # background color when cpu is medium

--- a/status/date_time.sh
+++ b/status/date_time.sh
@@ -1,7 +1,7 @@
 show_date_time() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "date_time"
   run_tmux_batch_commands
 
   index=$1

--- a/status/date_time.sh
+++ b/status/date_time.sh
@@ -1,7 +1,7 @@
 show_date_time() {
   local index icon color text module
 
-  tmux_batch_setup_module "date_time"
+  tmux_batch_setup_status_module "date_time"
   run_tmux_batch_commands
 
   index=$1

--- a/status/date_time.sh
+++ b/status/date_time.sh
@@ -1,10 +1,13 @@
 show_date_time() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon="$(get_tmux_option "@catppuccin_date_time_icon" "󰃰")"
-  color="$(get_tmux_option "@catppuccin_date_time_color" "$thm_blue")"
-  text="$(get_tmux_option "@catppuccin_date_time_text" "%Y-%m-%d %H:%M")"
+  icon="$(get_tmux_batch_option "@catppuccin_date_time_icon" "󰃰")"
+  color="$(get_tmux_batch_option "@catppuccin_date_time_color" "$thm_blue")"
+  text="$(get_tmux_batch_option "@catppuccin_date_time_text" "%Y-%m-%d %H:%M")"
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/directory.sh
+++ b/status/directory.sh
@@ -1,7 +1,7 @@
 show_directory() {
   local index icon color text module
 
-  tmux_batch_setup_module "directory"
+  tmux_batch_setup_status_module "directory"
   run_tmux_batch_commands
 
   index=$1

--- a/status/directory.sh
+++ b/status/directory.sh
@@ -1,7 +1,7 @@
 show_directory() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "directory"
   run_tmux_batch_commands
 
   index=$1

--- a/status/directory.sh
+++ b/status/directory.sh
@@ -1,10 +1,13 @@
 show_directory() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon=$(get_tmux_option "@catppuccin_directory_icon" "")
-  color=$(get_tmux_option "@catppuccin_directory_color" "$thm_pink")
-  text=$(get_tmux_option "@catppuccin_directory_text" "#{b:pane_current_path}")
+  icon=$(get_tmux_batch_option "@catppuccin_directory_icon" "")
+  color=$(get_tmux_batch_option "@catppuccin_directory_color" "$thm_pink")
+  text=$(get_tmux_batch_option "@catppuccin_directory_text" "#{b:pane_current_path}")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/gitmux.sh
+++ b/status/gitmux.sh
@@ -3,10 +3,13 @@
 show_gitmux() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon="$(get_tmux_option "@catppuccin_gitmux_icon"  "󰊢")"
-  color="$(get_tmux_option "@catppuccin_gitmux_color" "$thm_green")"
-  text="$(get_tmux_option "@catppuccin_gitmux_text"  "#(gitmux \"#{pane_current_path}\")")"
+  icon="$(get_tmux_batch_option "@catppuccin_gitmux_icon"  "󰊢")"
+  color="$(get_tmux_batch_option "@catppuccin_gitmux_color" "$thm_green")"
+  text="$(get_tmux_batch_option "@catppuccin_gitmux_text"  "#(gitmux \"#{pane_current_path}\")")"
 
   module=$( build_status_module "$index" "$icon" "$color" "$text" )
 

--- a/status/gitmux.sh
+++ b/status/gitmux.sh
@@ -3,7 +3,7 @@
 show_gitmux() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "gitmux"
   run_tmux_batch_commands
 
   index=$1

--- a/status/gitmux.sh
+++ b/status/gitmux.sh
@@ -3,7 +3,7 @@
 show_gitmux() {
   local index icon color text module
 
-  tmux_batch_setup_module "gitmux"
+  tmux_batch_setup_status_module "gitmux"
   run_tmux_batch_commands
 
   index=$1

--- a/status/host.sh
+++ b/status/host.sh
@@ -1,7 +1,7 @@
 show_host() {
   local index icon color text module
 
-  tmux_batch_setup_module "host"
+  tmux_batch_setup_status_module "host"
   run_tmux_batch_commands
 
   index=$1

--- a/status/host.sh
+++ b/status/host.sh
@@ -1,7 +1,7 @@
 show_host() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "host"
   run_tmux_batch_commands
 
   index=$1

--- a/status/host.sh
+++ b/status/host.sh
@@ -1,10 +1,13 @@
 show_host() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon=$(get_tmux_option "@catppuccin_host_icon" "󰒋")
-  color=$(get_tmux_option "@catppuccin_host_color" "$thm_magenta")
-  text=$(get_tmux_option "@catppuccin_host_text" "#H")
+  icon=$(get_tmux_batch_option "@catppuccin_host_icon" "󰒋")
+  color=$(get_tmux_batch_option "@catppuccin_host_color" "$thm_magenta")
+  text=$(get_tmux_batch_option "@catppuccin_host_text" "#H")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/kube.sh
+++ b/status/kube.sh
@@ -3,7 +3,7 @@
 show_kube() {
   local index icon color text context_color namespace_color symbol_enabled module
 
-  tmux_batch_setup_module "kube"
+  tmux_batch_setup_status_module "kube"
 
   add_tmux_batch_option "@catppuccin_kube_context_color"
   add_tmux_batch_option "@catppuccin_kube_namespace_color"

--- a/status/kube.sh
+++ b/status/kube.sh
@@ -11,14 +11,14 @@ show_kube() {
   run_tmux_batch_commands
 
   index=$1
-  icon=$(get_tmux_option "@catppuccin_kube_icon" "󱃾")
-  color=$(get_tmux_option "@catppuccin_kube_color" "$thm_blue")
-  context_color=$(get_tmux_option "@catppuccin_kube_context_color" "#{thm_red}")
-  namespace_color=$(get_tmux_option "@catppuccin_kube_namespace_color" "#{thm_cyan}")
+  icon=$(get_tmux_batch_option "@catppuccin_kube_icon" "󱃾")
+  color=$(get_tmux_batch_option "@catppuccin_kube_color" "$thm_blue")
+  context_color=$(get_tmux_batch_option "@catppuccin_kube_context_color" "#{thm_red}")
+  namespace_color=$(get_tmux_batch_option "@catppuccin_kube_namespace_color" "#{thm_cyan}")
   symbol_enabled=${KUBE_TMUX_SYMBOL_ENABLE:-false}
-  text=$(get_tmux_option "@catppuccin_kube_text" "#(KUBE_TMUX_SYMBOL_ENABLE=$symbol_enabled ${TMUX_PLUGIN_MANAGER_PATH}kube-tmux/kube.tmux 250 '$context_color' '$namespace_color')")
+  text=$(get_tmux_batch_option "@catppuccin_kube_text" "#(KUBE_TMUX_SYMBOL_ENABLE=$symbol_enabled ${TMUX_PLUGIN_MANAGER_PATH}kube-tmux/kube.tmux 250 '$context_color' '$namespace_color')")
 
-  module=$( build_status_module "$index" "$icon" "$color" "$text" )
+  module=$(build_status_module "$index" "$icon" "$color" "$text")
 
   echo "$module"
 }

--- a/status/kube.sh
+++ b/status/kube.sh
@@ -3,6 +3,13 @@
 show_kube() {
   local index icon color text context_color namespace_color symbol_enabled module
 
+  tmux_batch_setup_module "kube"
+
+  add_tmux_batch_option "@catppuccin_kube_context_color"
+  add_tmux_batch_option "@catppuccin_kube_namespace_color"
+
+  run_tmux_batch_commands
+
   index=$1
   icon=$(get_tmux_option "@catppuccin_kube_icon" "󱃾")
   color=$(get_tmux_option "@catppuccin_kube_color" "$thm_blue")

--- a/status/load.sh
+++ b/status/load.sh
@@ -1,7 +1,7 @@
 show_load() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "load"
   run_tmux_batch_commands
 
   index=$1

--- a/status/load.sh
+++ b/status/load.sh
@@ -1,7 +1,7 @@
 show_load() {
   local index icon color text module
 
-  tmux_batch_setup_module "load"
+  tmux_batch_setup_status_module "load"
   run_tmux_batch_commands
 
   index=$1

--- a/status/load.sh
+++ b/status/load.sh
@@ -1,10 +1,13 @@
 show_load() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon="$(get_tmux_option "@catppuccin_load_icon" "󰊚")"
-  color="$(get_tmux_option "@catppuccin_load_color" "$thm_blue")"
-  text="$(get_tmux_option "@catppuccin_load_text" "#{load_full}")"
+  icon="$(get_tmux_batch_option "@catppuccin_load_icon" "󰊚")"
+  color="$(get_tmux_batch_option "@catppuccin_load_color" "$thm_blue")"
+  text="$(get_tmux_batch_option "@catppuccin_load_text" "#{load_full}")"
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/pomodoro_plus.sh
+++ b/status/pomodoro_plus.sh
@@ -3,7 +3,7 @@
 show_pomodoro_plus() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "pomodoro_plus"
   run_tmux_batch_commands
 
   index=$1

--- a/status/pomodoro_plus.sh
+++ b/status/pomodoro_plus.sh
@@ -3,10 +3,13 @@
 show_pomodoro_plus() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon="$(  get_tmux_option "@catppuccin_pomodoro_plus_icon"  ""           )"
-  color="$( get_tmux_option "@catppuccin_pomodoro_plus_color" "$thm_orange" )"
-  text="$(  get_tmux_option "@catppuccin_pomodoro_plus_text"  "#{pomodoro_status}" )"
+  icon="$(  get_tmux_batch_option "@catppuccin_pomodoro_plus_icon"  ""           )"
+  color="$( get_tmux_batch_option "@catppuccin_pomodoro_plus_color" "$thm_orange" )"
+  text="$(  get_tmux_batch_option "@catppuccin_pomodoro_plus_text"  "#{pomodoro_status}" )"
 
   module=$( build_status_module "$index" "$icon" "$color" "$text" )
 

--- a/status/pomodoro_plus.sh
+++ b/status/pomodoro_plus.sh
@@ -3,7 +3,7 @@
 show_pomodoro_plus() {
   local index icon color text module
 
-  tmux_batch_setup_module "pomodoro_plus"
+  tmux_batch_setup_status_module "pomodoro_plus"
   run_tmux_batch_commands
 
   index=$1

--- a/status/session.sh
+++ b/status/session.sh
@@ -1,7 +1,7 @@
 show_session() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "session"
   run_tmux_batch_commands
 
   index=$1

--- a/status/session.sh
+++ b/status/session.sh
@@ -1,7 +1,7 @@
 show_session() {
   local index icon color text module
 
-  tmux_batch_setup_module "session"
+  tmux_batch_setup_status_module "session"
   run_tmux_batch_commands
 
   index=$1

--- a/status/session.sh
+++ b/status/session.sh
@@ -1,10 +1,13 @@
 show_session() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon=$(get_tmux_option "@catppuccin_session_icon" "")
-  color=$(get_tmux_option "@catppuccin_session_color" "#{?client_prefix,$thm_red,$thm_green}")
-  text=$(get_tmux_option "@catppuccin_session_text" "#S")
+  icon=$(get_tmux_batch_option "@catppuccin_session_icon" "")
+  color=$(get_tmux_batch_option "@catppuccin_session_color" "#{?client_prefix,$thm_red,$thm_green}")
+  text=$(get_tmux_batch_option "@catppuccin_session_text" "#S")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/uptime.sh
+++ b/status/uptime.sh
@@ -1,7 +1,7 @@
 show_uptime() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "uptime"
   run_tmux_batch_commands
 
   index=$1

--- a/status/uptime.sh
+++ b/status/uptime.sh
@@ -1,10 +1,13 @@
 show_uptime() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon="$(get_tmux_option "@catppuccin_uptime_icon" "󰔟")"
-  color="$(get_tmux_option "@catppuccin_uptime_color" "$thm_green")"
-  text="$(get_tmux_option "@catppuccin_uptime_text" "#(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')")"
+  icon="$(get_tmux_batch_option "@catppuccin_uptime_icon" "󰔟")"
+  color="$(get_tmux_batch_option "@catppuccin_uptime_color" "$thm_green")"
+  text="$(get_tmux_batch_option "@catppuccin_uptime_text" "#(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')")"
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/uptime.sh
+++ b/status/uptime.sh
@@ -1,7 +1,7 @@
 show_uptime() {
   local index icon color text module
 
-  tmux_batch_setup_module "uptime"
+  tmux_batch_setup_status_module "uptime"
   run_tmux_batch_commands
 
   index=$1

--- a/status/user.sh
+++ b/status/user.sh
@@ -1,10 +1,13 @@
 show_user() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon=$(get_tmux_option "@catppuccin_user_icon" "")
-  color=$(get_tmux_option "@catppuccin_user_color" "$thm_cyan")
-  text=$(get_tmux_option "@catppuccin_user_text" "#(whoami)")
+  icon=$(get_tmux_batch_option "@catppuccin_user_icon" "")
+  color=$(get_tmux_batch_option "@catppuccin_user_color" "$thm_cyan")
+  text=$(get_tmux_batch_option "@catppuccin_user_text" "#(whoami)")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/user.sh
+++ b/status/user.sh
@@ -1,7 +1,7 @@
 show_user() {
   local index icon color text module
 
-  tmux_batch_setup_module "user"
+  tmux_batch_setup_status_module "user"
   run_tmux_batch_commands
 
   index=$1

--- a/status/user.sh
+++ b/status/user.sh
@@ -1,7 +1,7 @@
 show_user() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "user"
   run_tmux_batch_commands
 
   index=$1

--- a/status/weather.sh
+++ b/status/weather.sh
@@ -3,7 +3,7 @@
 show_weather() {
   local index icon color text module
 
-  tmux_batch_setup_module "application"
+  tmux_batch_setup_module "weather"
   run_tmux_batch_commands
 
   index=$1

--- a/status/weather.sh
+++ b/status/weather.sh
@@ -3,10 +3,13 @@
 show_weather() {
   local index icon color text module
 
+  tmux_batch_setup_module "application"
+  run_tmux_batch_commands
+
   index=$1
-  icon="$(get_tmux_option "@catppuccin_weather_icon" "")"
-  color="$(get_tmux_option "@catppuccin_weather_color" "$thm_yellow")"
-  text="$(get_tmux_option "@catppuccin_weather_text" "#{weather}")"
+  icon="$(get_tmux_batch_option "@catppuccin_weather_icon" "")"
+  color="$(get_tmux_batch_option "@catppuccin_weather_color" "$thm_yellow")"
+  text="$(get_tmux_batch_option "@catppuccin_weather_text" "#{weather}")"
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 

--- a/status/weather.sh
+++ b/status/weather.sh
@@ -3,7 +3,7 @@
 show_weather() {
   local index icon color text module
 
-  tmux_batch_setup_module "weather"
+  tmux_batch_setup_status_module "weather"
   run_tmux_batch_commands
 
   index=$1

--- a/utils/tmux_utils.sh
+++ b/utils/tmux_utils.sh
@@ -57,78 +57,78 @@ setw() {
 }
 
 get_tmux_batch_option() {
-	local option default value
-	option="$1"
+  local option default value
+  option="$1"
   default="$2"
 
-	for option_index in "${!tmux_batch_options[@]}"; do
-		IFS=":" read -r read_option read_value <<<"${tmux_batch_options[$option_index]}"
-		if [[ "$read_option" == "$option" ]]; then
-			echo "$read_value"
+  for option_index in "${!tmux_batch_options[@]}"; do
+    IFS=":" read -r read_option read_value <<<"${tmux_batch_options[$option_index]}"
+    if [[ "$read_option" == "$option" ]]; then
+      echo "$read_value"
       return
-		fi
-	done
+    fi
+  done
 
   echo "$default"
 }
 
 get_interpolated_tmux_batch_option() {
-	local option default value
-	option="$1"
+  local option default value
+  option="$1"
   default="$2"
 
-	for option_index in "${!tmux_batch_options[@]}"; do
-		IFS=":" read -r read_option read_value <<<"${tmux_batch_options[$option_index]}"
-		if [[ "$read_option" == "$option" ]]; then
+  for option_index in "${!tmux_batch_options[@]}"; do
+    IFS=":" read -r read_option read_value <<<"${tmux_batch_options[$option_index]}"
+    if [[ "$read_option" == "$option" ]]; then
       do_color_interpolation "$read_value"
       return
-		fi
-	done
+    fi
+  done
 
   echo "$default"
 }
 
 add_tmux_batch_option() {
-	local option
-	option="$1"
+  local option
+  option="$1"
 
-	tmux_batch_options_commands+=("show-option -gq $option ;")
+  tmux_batch_options_commands+=("show-option -gq $option ;")
 }
 
 set_tmux_batch_option() {
-	local option value
-	option="$1"
-	value="$2"
+  local option value
+  option="$1"
+  value="$2"
 
-	for option_index in "${!tmux_batch_options[@]}"; do
-		read -d ':' -r read_option <<<"${tmux_batch_options[$option_index]}"
-		if [[ "$read_option" == "$option" ]]; then
-			tmux_batch_options["$option_index"]="$option:$value"
-			return
-		fi
-	done
+  # NOTE: don't check for duplicates just append
+  # for option_index in "${!tmux_batch_options[@]}"; do
+  #   read -d ':' -r read_option <<<"${tmux_batch_options[$option_index]}"
+  #   if [[ "$read_option" == "$option" ]]; then
+  #     tmux_batch_options["$option_index"]="$option:$value"
+  #     return
+  #   fi
+  # done
 
   tmux_batch_options+=("$option:$value")
-	tmux_batch_options_commands+=("show-option -gq $option ;")
 }
 
 run_tmux_batch_commands() {
-	local temp
+  local temp
 
   # shellcheck disable=SC2048,SC2086
-	while IFS=' ' read -r option value; do
-		if [ -n "$value" ]; then
-			if [ "$value" = "null" ]; then
-				set_tmux_batch_option "$option" ""
-			else
-				temp="${value%\"}"
-				temp="${temp#\"}"
-				set_tmux_batch_option "$option" "$temp"
-			fi
-		fi
-	done < <(tmux ${tmux_batch_options_commands[*]})
+  while IFS=' ' read -r option value; do
+    if [ -n "$value" ]; then
+      if [ "$value" = "null" ]; then
+        set_tmux_batch_option "$option" ""
+      else
+        temp="${value%\"}"
+        temp="${temp#\"}"
+        set_tmux_batch_option "$option" "$temp"
+      fi
+    fi
+  done < <(tmux ${tmux_batch_options_commands[*]})
 
-	tmux_batch_options_commands=()
+  tmux_batch_options_commands=()
 }
 
 tmux_batch_setup_module() {

--- a/utils/tmux_utils.sh
+++ b/utils/tmux_utils.sh
@@ -131,7 +131,7 @@ run_tmux_batch_commands() {
   tmux_batch_options_commands=()
 }
 
-tmux_batch_setup_module() {
+tmux_batch_setup_status_module() {
   local name="$1"
 
   # Don't want to run commands set before since we can't update

--- a/utils/tmux_utils.sh
+++ b/utils/tmux_utils.sh
@@ -16,11 +16,9 @@ get_tmux_option() {
     if [ "$value" = "null" ]
     then
       echo ""
-
     else
       echo "$value"
     fi
-
   else
     echo "$default"
 
@@ -38,11 +36,9 @@ get_interpolated_tmux_option() {
     if [ "$value" = "null" ]
     then
       echo ""
-
     else
       do_color_interpolation "$value"
     fi
-
   else
     echo "$default"
   fi
@@ -58,4 +54,96 @@ setw() {
   local option=$1
   local value=$2
   tmux_commands+=(set-window-option -gq "$option" "$value" ";")
+}
+
+get_tmux_batch_option() {
+	local option default value
+	option="$1"
+  default="$2"
+
+	for option_index in "${!tmux_batch_options[@]}"; do
+		IFS=":" read -r read_option read_value <<<"${tmux_batch_options[$option_index]}"
+		if [[ "$read_option" == "$option" ]]; then
+			echo "$read_value"
+      return
+		fi
+	done
+
+  echo "$default"
+}
+
+get_interpolated_tmux_batch_option() {
+	local option default value
+	option="$1"
+  default="$2"
+
+	for option_index in "${!tmux_batch_options[@]}"; do
+		IFS=":" read -r read_option read_value <<<"${tmux_batch_options[$option_index]}"
+		if [[ "$read_option" == "$option" ]]; then
+      do_color_interpolation "$read_value"
+      return
+		fi
+	done
+
+  echo "$default"
+}
+
+add_tmux_batch_option() {
+	local option
+	option="$1"
+
+	tmux_batch_options_commands+=("show-option -gq $option ;")
+}
+
+set_tmux_batch_option() {
+	local option value
+	option="$1"
+	value="$2"
+
+	for option_index in "${!tmux_batch_options[@]}"; do
+		read -d ':' -r read_option <<<"${tmux_batch_options[$option_index]}"
+		if [[ "$read_option" == "$option" ]]; then
+			tmux_batch_options["$option_index"]="$option:$value"
+			return
+		fi
+	done
+
+  tmux_batch_options+=("$option:$value")
+	tmux_batch_options_commands+=("show-option -gq $option ;")
+}
+
+run_tmux_batch_commands() {
+	local temp
+
+  # shellcheck disable=SC2048,SC2086
+	while IFS=' ' read -r option value; do
+		if [ -n "$value" ]; then
+			if [ "$value" = "null" ]; then
+				set_tmux_batch_option "$option" ""
+			else
+				temp="${value%\"}"
+				temp="${temp#\"}"
+				set_tmux_batch_option "$option" "$temp"
+			fi
+		fi
+	done < <(tmux ${tmux_batch_options_commands[*]})
+
+	tmux_batch_options_commands=()
+}
+
+tmux_batch_setup_module() {
+  local name="$1"
+
+  # Don't want to run commands set before since we can't update
+  # `tmux_batch_options` for it
+  # shellcheck disable=SC2034
+  tmux_batch_options_commands=()
+
+  # No need to check previous options
+  # shellcheck disable=SC2034
+  tmux_batch_options=()
+
+  add_tmux_batch_option "@catppuccin_${name}_icon"
+  add_tmux_batch_option "@catppuccin_${name}_color"
+  add_tmux_batch_option "@catppuccin_${name}_text"
 }

--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -2,10 +2,10 @@ show_window_current_format() {
   local number color background text fill current_window_format
 
   number="#I"
-  color=$(get_tmux_option "@catppuccin_window_current_color" "$thm_orange")
-  background=$(get_tmux_option "@catppuccin_window_current_background" "$thm_bg")
-  text="$(get_tmux_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
-  fill="$(get_tmux_option "@catppuccin_window_current_fill" "number")"                 # number, all, none
+  color=$(get_tmux_batch_option "@catppuccin_window_current_color" "$thm_orange")
+  background=$(get_tmux_batch_option "@catppuccin_window_current_background" "$thm_bg")
+  text="$(get_tmux_batch_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
+  fill="$(get_tmux_batch_option "@catppuccin_window_current_fill" "number")"                 # number, all, none
 
   current_window_format=$(build_window_format "$number" "$color" "$background" "$text" "$fill")
 

--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -1,5 +1,16 @@
 show_window_current_format() {
   local number color background text fill current_window_format
+  # shellcheck disable=SC2034
+  local tmux_batch_options_commands=()
+  # shellcheck disable=SC2034
+  local tmux_batch_options=()
+
+  add_tmux_batch_option "@catppuccin_window_current_color"
+  add_tmux_batch_option "@catppuccin_window_current_background"
+  add_tmux_batch_option "@catppuccin_window_current_text"
+  add_tmux_batch_option "@catppuccin_window_current_fill"
+
+  run_tmux_batch_commands
 
   number="#I"
   color=$(get_tmux_batch_option "@catppuccin_window_current_color" "$thm_orange")

--- a/window/window_default_format.sh
+++ b/window/window_default_format.sh
@@ -1,5 +1,16 @@
 show_window_default_format() {
   local number color background text fill default_window_format
+  # shellcheck disable=SC2034
+  local tmux_batch_options_commands=()
+  # shellcheck disable=SC2034
+  local tmux_batch_options=()
+
+  add_tmux_batch_option "@catppuccin_window_default_color"
+  add_tmux_batch_option "@catppuccin_window_default_background"
+  add_tmux_batch_option "@catppuccin_window_default_text"
+  add_tmux_batch_option "@catppuccin_window_default_fill"
+
+  run_tmux_batch_commands
 
   number="#I"
   color=$(get_tmux_batch_option "@catppuccin_window_default_color" "$thm_blue")

--- a/window/window_default_format.sh
+++ b/window/window_default_format.sh
@@ -2,10 +2,10 @@ show_window_default_format() {
   local number color background text fill default_window_format
 
   number="#I"
-  color=$(get_tmux_option "@catppuccin_window_default_color" "$thm_blue")
-  background=$(get_tmux_option "@catppuccin_window_default_background" "$thm_gray")
-  text="$(get_tmux_option "@catppuccin_window_default_text" "#{b:pane_current_path}")" # use #W for application instead of directory
-  fill="$(get_tmux_option "@catppuccin_window_default_fill" "number")"                 # number, all, none
+  color=$(get_tmux_batch_option "@catppuccin_window_default_color" "$thm_blue")
+  background=$(get_tmux_batch_option "@catppuccin_window_default_background" "$thm_gray")
+  text="$(get_tmux_batch_option "@catppuccin_window_default_text" "#{b:pane_current_path}")" # use #W for application instead of directory
+  fill="$(get_tmux_batch_option "@catppuccin_window_default_fill" "number")"                 # number, all, none
 
   default_window_format=$(build_window_format "$number" "$color" "$background" "$text" "$fill")
 


### PR DESCRIPTION
Batching tmux show-options gives a significant start uptime decrease of up to 3 under linux (tested with bath bash-5.2.26 and 3.2.57).

~~On the bash version used by macos this however seems to have a negative impact. This was test in docker with as image `bash:3.2.57-alpine3.19`. The negative impact maybe from docker/alpine since in `bash:5.1-alpine3.19` it also had a negative impact but less.
Can anyone on macos see what the real effect is?~~


~~I think the the complexity increase is worth it if the "macos"/old bash/alpine hit is because of alpine, but would love to get more feedback on this.~~
Effect was docker/alpine build bash-3.2.57 and it works great.

Tested on 10 user configs (from issues) with and without batching and batching was always an improvement.

With defaults in the array is most of the time slower but did not spend any time in looking for improvements since the with defaults is a bit more user friendly.


- Example config 1
![Screenshot from 2024-07-14 16-32-33](https://github.com/user-attachments/assets/5109a72d-9112-4fe5-a111-89233e240f8e)



- Example config 2
![Screenshot from 2024-07-14 16-35-22](https://github.com/user-attachments/assets/53db19e5-5129-45d8-af12-f45bb43fab4a)


- Example config 3
![Screenshot from 2024-07-14 16-38-49](https://github.com/user-attachments/assets/5fd45a7e-63bb-4972-88c4-b249b61a515b)