### PR TITLE
Add support to tmux-pomodoro-plus plugin in status bar

### DIFF
--- a/status/pomodoro_plus.sh
+++ b/status/pomodoro_plus.sh
@@ -1,0 +1,14 @@
+# Requires https://github.com/olimorris/tmux-pomodoro-plus
+
+show_pomodoro_plus() {
+  local index icon color text module
+
+  index=$1
+  icon="$(  get_tmux_option "@catppuccin_<module_name>_icon"  ""           )"
+  color="$( get_tmux_option "@catppuccin_<module_name>_color" "$thm_orange" )"
+  text="$(  get_tmux_option "@catppuccin_<module_name>_text"  "#{pomodoro_status}" )"
+
+  module=$( build_status_module "$index" "$icon" "$color" "$text" )
+
+  echo "$module"
+}


### PR DESCRIPTION
Add suport to [pomodoro plugin](https://github.com/olimorris/tmux-pomodoro-plus) in status bar by calling the pomodoro method `#{pomodoro_status}` in catppuccino's module text field.