### PR TITLE
feat: warning when trying to load a missing module

### DIFF
--- a/utils/module_utils.sh
+++ b/utils/module_utils.sh
@@ -29,9 +29,12 @@ load_modules() {
         source "$module_path"
         loaded_modules="$loaded_modules$( "show_$module_name" "$module_index" )"
         module_index+=1
-        break
+        continue 2
       fi
     done
+    tmux_echo "catppuccin warning: module $module_name not found"
+
+
   done
 
   echo "$loaded_modules"

--- a/utils/tmux_utils.sh
+++ b/utils/tmux_utils.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+tmux_echo() {
+  local message="$1"
+  tmux run-shell "echo '$message'"
+}
+
 get_tmux_option() {
   local option value default
   option="$1"


### PR DESCRIPTION
print/echo a warning when a `catppuccin_status_modules_right/left` is trying to load a none existing module.
This does only work when reloading (`tmux source ~/.tmux.conf` / `tmux source ~/.config/tmux/tmux.conf`)

closes #243 