### PR TITLE
fixup! fix: status module trailing space transparancy (#250)

### DIFF
--- a/builder/module_builder.sh
+++ b/builder/module_builder.sh
@@ -9,6 +9,7 @@ build_status_module() {
   if [ "$status_fill" = "icon" ]; then
     local bg
     local show_icon="#[fg=$thm_bg,bg=$color,nobold,nounderscore,noitalics]$icon "
+    local show_text="#[fg=$thm_fg,bg=$thm_gray] $text"
 
     if [ "$status_connect_separator" = "yes" ]; then
       bg="$thm_gray"
@@ -16,7 +17,6 @@ build_status_module() {
       bg="default"
     fi
 
-    local show_text="#[fg=$thm_fg,bg=$bg] $text"
     local show_left_separator="#[fg=$color,bg=$bg,nobold,nounderscore,noitalics]$status_left_separator"
     local show_right_separator="#[fg=$thm_gray,bg=$bg,nobold,nounderscore,noitalics]$status_right_separator"
   fi


### PR DESCRIPTION
don't change `show_text`

closes: #252