### PR TITLE
fix(uptime): filter out singular "user" string in sed expression

### DIFF
--- a/status/uptime.sh
+++ b/status/uptime.sh
@@ -4,7 +4,7 @@ show_uptime() {
   index=$1
   icon="$(get_tmux_option "@catppuccin_uptime_icon" "󰔟")"
   color="$(get_tmux_option "@catppuccin_uptime_color" "$thm_green")"
-  text="$(get_tmux_option "@catppuccin_uptime_text" "#(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* users.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')")"
+  text="$(get_tmux_option "@catppuccin_uptime_text" "#(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')")"
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 


### PR DESCRIPTION
Previously, on machines where the logged-in user count is 1, the `sed` expression to filter out "... X users, ..." doesn't filter out "... X user, ...", leading to something like

```
1h 05,  1 user,  load average: 0.05, 0.72, 1.62m
```

being displayed in the module. When the user count is greater than 1 (e.g., after `ssh localhost`), the `uptime` module displays

```
1h 05m
```

as expected.

With this patch, the module display correctly when the user count is 1.

The Stack Overflow answer the `sed` expression is based on [^1][^2] doesn't seem to consider the case when the user count is 1.

[^1]: https://stackoverflow.com/a/28353785
[^2]: https://github.com/catppuccin/tmux/pull/163