### PR TITLE
Improve the handling of separation between window title and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Values:
 - yes - this will replace the windows status text with icons
 - no - this will keep the windows status in text format
 
+#### Set window status icon/text separator:
+```sh
+set -g @catppuccin_window_status_separator " "
+```
+The character to use for separating window text and status.
+
 #### Override windows status icons
 ```sh
 set -g @catppuccin_icon_window_last "󰖰"

--- a/builder/window_builder.sh
+++ b/builder/window_builder.sh
@@ -93,34 +93,36 @@ build_window_format() {
 }
 
 build_window_icon() {
-  local window_status_icon_enable custom_icon_window_last \
+  local window_status_icon_enable window_status_separator custom_icon_window_last \
     custom_icon_window_zoom custom_icon_window_mark custom_icon_window_mark \
     custom_icon_window_silent custom_icon_window_activity custom_icon_window_bell
 
   window_status_icon_enable=$(get_tmux_option "@catppuccin_window_status_icon_enable" "yes")
-  custom_icon_window_last=$(get_tmux_option "@catppuccin_icon_window_last" "󰖰")
-  custom_icon_window_current=$(get_tmux_option "@catppuccin_icon_window_current" "󰖯")
-  custom_icon_window_zoom=$(get_tmux_option "@catppuccin_icon_window_zoom" "󰁌")
-  custom_icon_window_mark=$(get_tmux_option "@catppuccin_icon_window_mark" "󰃀")
-  custom_icon_window_silent=$(get_tmux_option "@catppuccin_icon_window_silent" "󰂛")
-  custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫")
-  custom_icon_window_bell=$(get_tmux_option "@catppuccin_icon_window_bell" "󰂞")
+
+  window_status_separator=$(get_tmux_option     "@catppuccin_window_status_separator" " ")
+  custom_icon_window_last=$(get_tmux_option     "@catppuccin_icon_window_last"     "󰖰" "${window_status_separator}")
+  custom_icon_window_current=$(get_tmux_option  "@catppuccin_icon_window_current"  "󰖯" "${window_status_separator}")
+  custom_icon_window_zoom=$(get_tmux_option     "@catppuccin_icon_window_zoom"     "󰁌" "${window_status_separator}")
+  custom_icon_window_mark=$(get_tmux_option     "@catppuccin_icon_window_mark"     "󰃀" "${window_status_separator}")
+  custom_icon_window_silent=$(get_tmux_option   "@catppuccin_icon_window_silent"   "󰂛" "${window_status_separator}")
+  custom_icon_window_activity=$(get_tmux_option "@catppuccin_icon_window_activity" "󱅫" "${window_status_separator}")
+  custom_icon_window_bell=$(get_tmux_option     "@catppuccin_icon_window_bell"     "󰂞" "${window_status_separator}")
 
   if [ "$window_status_icon_enable" = "yes" ]; then
     # #!~[*-]MZ
     local show_window_status=""
-    show_window_status+="#{?window_activity_flag, ${custom_icon_window_activity},}"
-    show_window_status+="#{?window_bell_flag, ${custom_icon_window_bell},}"
-    show_window_status+="#{?window_silence_flag, ${custom_icon_window_silent},}"
-    show_window_status+="#{?window_active, ${custom_icon_window_current},}"
-    show_window_status+="#{?window_last_flag, ${custom_icon_window_last},}"
-    show_window_status+="#{?window_marked_flag, ${custom_icon_window_mark},}"
-    show_window_status+="#{?window_zoomed_flag, ${custom_icon_window_zoom},}"
+    show_window_status+="#{?window_activity_flag,${custom_icon_window_activity},}"
+    show_window_status+="#{?window_bell_flag,${custom_icon_window_bell},}"
+    show_window_status+="#{?window_silence_flag,${custom_icon_window_silent},}"
+    show_window_status+="#{?window_active,${custom_icon_window_current},}"
+    show_window_status+="#{?window_last_flag,${custom_icon_window_last},}"
+    show_window_status+="#{?window_marked_flag,${custom_icon_window_mark},}"
+    show_window_status+="#{?window_zoomed_flag,${custom_icon_window_zoom},}"
 
   fi
 
   if [ "$window_status_icon_enable" = "no" ]; then
-    local show_window_status=" #F"
+    local show_window_status="${window_status_separator}#F"
   fi
 
   echo "$show_window_status"

--- a/utils/tmux_utils.sh
+++ b/utils/tmux_utils.sh
@@ -6,24 +6,32 @@ tmux_echo() {
 }
 
 get_tmux_option() {
-  local option value default
+  local option value default sep_before sep_after res
   option="$1"
   default="$2"
+  sep_before="$3" # optional separator, prepended to the result if value not empty
+  sep_after="$4"  # optional separator, appended to the result if value not empty
+
   value=$(tmux show-option -gqv "$option")
+  res=""
 
   if [ -n "$value" ]
   then
     if [ "$value" = "null" ]
     then
-      echo ""
-
+      res=""
     else
-      echo "$value"
+      res="$value"
     fi
-
   else
-    echo "$default"
+    res="$default"
+  fi
 
+  if [ -n "$res" ]
+  then
+    echo "${sep_before}${res}${sep_after}"
+  else
+    echo "$res"
   fi
 }
 


### PR DESCRIPTION
1. Before, it was always separated by space, now the separator can be changed or removed via global option
2. Now, the separator is only added if there is an actual status to display. Works for custom separator icons only.