### PR TITLE
Don't add icon separator if there is no icon for a status module

### DIFF
--- a/builder/module_builder.sh
+++ b/builder/module_builder.sh
@@ -40,5 +40,9 @@ build_status_module() {
     local show_left_separator="#[fg=$color,bg=default,nobold,nounderscore,noitalics]$status_left_separator"
   fi
 
+  if [ -z "$icon" ] ; then
+    show_icon=""
+  fi
+
   echo "$show_left_separator$show_icon$show_text$show_right_separator"
 }


### PR DESCRIPTION
When rendering status modules, there is a separator between the icon and the module text. Before, it was redundantly shown even when the module icon was disabled by the user.