### PR TITLE
feat: warn users of whitespace in module lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ set -g @catppuccin_pane_background_color "#{thm_orange}"
 #### Set the module list
 ```sh
 set -g @catppuccin_status_modules_right "application session"
-set -g @catppuccin_status_modules_left ""
+set -g @catppuccin_status_modules_left "null"
 ```
 Provide a list of modules and the order in which you want them to appear in the status.
 

--- a/utils/module_utils.sh
+++ b/utils/module_utils.sh
@@ -32,6 +32,16 @@ load_modules() {
         continue 2
       fi
     done
+
+    if [[ -z "${module_name/ }" ]]; then
+      if [[ -z "${modules_list/ }" ]]; then
+        tmux_echo "catppuccin warning: a module list has only white space, to remove all modules set it to \"null\""
+      else
+        tmux_echo "catppuccin warning: a module list with value \"$modules_list\" has leading/trailing whitespace"
+      fi
+      continue
+    fi
+
     tmux_echo "catppuccin warning: module $module_name not found"
 
 


### PR DESCRIPTION
`set -g @catppuccin_status_modules_right " "` will try to load ` ` as a module same with `set -g @catppuccin_status_modules_left "session "`.

The proper way to clear modules is `set -g @catppuccin_status_modules_right "null"` 

Fixes: #263