### PR TITLE
Use full theme colors and use palette naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Values:
 
 #### Override the window current colors:
 ```sh
-set -g @catppuccin_window_current_color "#{thm_orange}" # text color
+set -g @catppuccin_window_current_color "#{thm_peach}" # text color
 set -g @catppuccin_window_current_background "#{thm_bg}"
 ```
 Note that color and background fields are swapped when `@catppuccin_window_current_fill` is set to "all".
@@ -206,7 +206,7 @@ set -g @catppuccin_pane_border_style "fg=#{thm_gray}" # Use a value compatible w
 #### Set the pane active border style:
 
 ```sh
-set -g @catppuccin_pane_active_border_style "fg=#{thm_orange}" # Use a value compatible with the standard tmux 'pane-border-active-style'
+set -g @catppuccin_pane_active_border_style "fg=#{thm_peach}" # Use a value compatible with the standard tmux 'pane-border-active-style'
 ```
 
 ### Menu
@@ -298,10 +298,10 @@ set -g @catppuccin_pane_middle_separator "█"
 set -g @catppuccin_pane_number_position "left"
 set -g @catppuccin_pane_default_fill "number"
 set -g @catppuccin_pane_default_text "#{b:pane_current_path}"
-set -g @catppuccin_pane_border_style "fg=#{thm_orange}"
-set -g @catppuccin_pane_active_border_style "fg=#{thm_orange}"
-set -g @catppuccin_pane_color "#{thm_orange}"
-set -g @catppuccin_pane_background_color "#{thm_orange}"
+set -g @catppuccin_pane_border_style "fg=#{thm_peach}"
+set -g @catppuccin_pane_active_border_style "fg=#{thm_peach}"
+set -g @catppuccin_pane_color "#{thm_peach}"
+set -g @catppuccin_pane_background_color "#{thm_peach}"
 ```
 
 #### Set the module list
@@ -521,7 +521,7 @@ set -g @catppuccin_status_modules_right "... kube ..."
 Optionally override the kube-tmux colors
 ```sh
 set -g @catppuccin_kube_context_color "#{thm_red}"
-set -g @catppuccin_kube_namespace_color "#{thm_cyan}"
+set -g @catppuccin_kube_namespace_color "#{thm_sky}"
 ```
 
 

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -82,8 +82,8 @@ main() {
   set status-right-length "100"
 
   # messages
-  set message-style "fg=${thm_cyan},bg=${message_background},align=centre"
-  set message-command-style "fg=${thm_cyan},bg=${message_background},align=centre"
+  set message-style "fg=${thm_sky},bg=${message_background},align=centre"
+  set message-command-style "fg=${thm_sky},bg=${message_background},align=centre"
 
   # menu
   local menu_style menu_selected_style menu_border_style
@@ -105,7 +105,7 @@ main() {
   )
   pane_active_border_style=$(
     get_interpolated_tmux_option "@catppuccin_pane_active_border_style" \
-      "#{?pane_in_mode,fg=${thm_yellow},#{?pane_synchronized,fg=${thm_magenta},fg=${thm_orange}}}"
+      "#{?pane_in_mode,fg=${thm_yellow},#{?pane_synchronized,fg=${thm_mauve},fg=${thm_peach}}}"
   )
   pane_left_separator=$(get_tmux_option "@catppuccin_pane_left_separator" "█")
   pane_middle_separator=$(get_tmux_option "@catppuccin_pane_middle_separator" "█")
@@ -156,7 +156,7 @@ main() {
 
   # modes
   setw clock-mode-colour "${thm_blue}"
-  setw mode-style "fg=${thm_pink} bg=${thm_black4} bold"
+  setw mode-style "fg=${thm_pink} bg=${thm_surface2} bold"
 
   tmux "${tmux_commands[@]}"
 }

--- a/status/cpu.sh
+++ b/status/cpu.sh
@@ -7,7 +7,7 @@ show_cpu() {
   text="$(get_tmux_option "@catppuccin_cpu_text" "#{cpu_percentage}")"
 
   tmux set-option -g @cpu_low_bg_color "$thm_yellow"    # background color when cpu is low
-  tmux set-option -g @cpu_medium_bg_color "$thm_orange" # background color when cpu is medium
+  tmux set-option -g @cpu_medium_bg_color "$thm_peach" # background color when cpu is medium
   tmux set-option -g @cpu_high_bg_color "$thm_red"      # background color when cpu is high
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")

--- a/status/host.sh
+++ b/status/host.sh
@@ -3,7 +3,7 @@ show_host() {
 
   index=$1
   icon=$(get_tmux_option "@catppuccin_host_icon" "󰒋")
-  color=$(get_tmux_option "@catppuccin_host_color" "$thm_magenta")
+  color=$(get_tmux_option "@catppuccin_host_color" "$thm_mauve")
   text=$(get_tmux_option "@catppuccin_host_text" "#H")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")

--- a/status/kube.sh
+++ b/status/kube.sh
@@ -7,7 +7,7 @@ show_kube() {
   icon=$(get_tmux_option "@catppuccin_kube_icon" "󱃾")
   color=$(get_tmux_option "@catppuccin_kube_color" "$thm_blue")
   context_color=$(get_tmux_option "@catppuccin_kube_context_color" "#{thm_red}")
-  namespace_color=$(get_tmux_option "@catppuccin_kube_namespace_color" "#{thm_cyan}")
+  namespace_color=$(get_tmux_option "@catppuccin_kube_namespace_color" "#{thm_sky}")
   symbol_enabled=${KUBE_TMUX_SYMBOL_ENABLE:-false}
   text=$(get_tmux_option "@catppuccin_kube_text" "#(KUBE_TMUX_SYMBOL_ENABLE=$symbol_enabled ${TMUX_PLUGIN_MANAGER_PATH}kube-tmux/kube.tmux 250 '$context_color' '$namespace_color')")
 

--- a/status/pomodoro_plus.sh
+++ b/status/pomodoro_plus.sh
@@ -5,7 +5,7 @@ show_pomodoro_plus() {
 
   index=$1
   icon="$(  get_tmux_option "@catppuccin_<module_name>_icon"  ""           )"
-  color="$( get_tmux_option "@catppuccin_<module_name>_color" "$thm_orange" )"
+  color="$( get_tmux_option "@catppuccin_<module_name>_color" "$thm_peach" )"
   text="$(  get_tmux_option "@catppuccin_<module_name>_text"  "#{pomodoro_status}" )"
 
   module=$( build_status_module "$index" "$icon" "$color" "$text" )

--- a/status/user.sh
+++ b/status/user.sh
@@ -3,7 +3,7 @@ show_user() {
 
   index=$1
   icon=$(get_tmux_option "@catppuccin_user_icon" "")
-  color=$(get_tmux_option "@catppuccin_user_color" "$thm_cyan")
+  color=$(get_tmux_option "@catppuccin_user_color" "$thm_sky")
   text=$(get_tmux_option "@catppuccin_user_text" "#(whoami)")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")

--- a/themes/catppuccin_frappe.tmuxtheme
+++ b/themes/catppuccin_frappe.tmuxtheme
@@ -2,16 +2,40 @@
 # WARNING: hex colors can't contain capital letters
 
 # --> Catppuccin (Frappe)
+# Base colors
 thm_bg="#303446"
 thm_fg="#c6d0f5"
-thm_cyan="#99d1db"
-thm_black="#292c3c"
-thm_gray="#414559"
-thm_magenta="#ca9ee6"
+
+thm_rosewater="#f2d5cf"
+thm_flamingo="#eebebe"
 thm_pink="#f4b8e4"
+thm_mauve="#ca9ee6"
 thm_red="#e78284"
-thm_green="#a6d189"
+thm_maroon="#ea999c"
+thm_peach="#ef9f76"
 thm_yellow="#e5c890"
+thm_green="#a6d189"
+thm_teal="#81c8be"
+thm_sky="#99d1db"
+thm_sapphire="#85c1dc"
 thm_blue="#8caaee"
-thm_orange="#ef9f76"
-thm_black4="#626880"
+thm_lavender="#babbf1"
+
+thm_surface2="#626880"
+thm_surface1="#51576d"
+thm_surface0="#414559"
+thm_overlay2="#949cbb"
+thm_overlay1="#838ba7"
+thm_overlay0="#737994"
+
+thm_black="#292c3c" # mantle
+thm_gray="#414559" # surface 0
+
+# DEPRECATED, use sky instead
+thm_cyan="${thm_sky}"
+# DEPRECATED, use mauve instead
+thm_magenta="${thm_mauve}"
+# DEPRECATED, use peach instead
+thm_orange="${thm_peach}"
+# DEPRECATED, use surface2 instead
+thm_black4="${thm_surface2}"

--- a/themes/catppuccin_latte.tmuxtheme
+++ b/themes/catppuccin_latte.tmuxtheme
@@ -2,16 +2,40 @@
 # WARNING: hex colors can't contain capital letters
 
 # --> Catppuccin (Latte)
+# Base colors
 thm_bg="#eff1f5"
 thm_fg="#4c4f69"
-thm_cyan="#04a5e5"
-thm_black="#e6e9ef"
-thm_gray="#ccd0da"
-thm_magenta="#8839ef"
+
+thm_rosewater="#dc8a78"
+thm_flamingo="#dd7878"
 thm_pink="#ea76cb"
+thm_mauve="#8839ef"
 thm_red="#d20f39"
-thm_green="#40a02b"
+thm_maroon="#e64553"
+thm_peach="#fe640b"
 thm_yellow="#df8e1d"
+thm_green="#40a02b"
+thm_teal="#179299"
+thm_sky="#04a5e5"
+thm_sapphire="#209fb5"
 thm_blue="#1e66f5"
-thm_orange="#fe640b"
-thm_black4="#acb0be"
+thm_lavender="#7287fd"
+
+thm_surface2="#acb0be"
+thm_surface1="#bcc0cc"
+thm_surface0="#ccd0da"
+thm_overlay2="#7c7f93"
+thm_overlay1="#8c8fa1"
+thm_overlay0="#9ca0b0"
+
+thm_black="#e6e9ef" # mantle
+thm_gray="#ccd0da" # surface 0
+
+# DEPRECATED, use sky instead
+thm_cyan="${thm_sky}"
+# DEPRECATED, use mauve instead
+thm_magenta="${thm_mauve}"
+# DEPRECATED, use peach instead
+thm_orange="${thm_peach}"
+# DEPRECATED, use surface2 instead
+thm_black4="${thm_surface2}"

--- a/themes/catppuccin_macchiato.tmuxtheme
+++ b/themes/catppuccin_macchiato.tmuxtheme
@@ -2,16 +2,40 @@
 # WARNING: hex colors can't contain capital letters
 
 # --> Catppuccin (Macchiato)
+# Base colors
 thm_bg="#24273a"
 thm_fg="#cad3f5"
-thm_cyan="#91d7e3"
-thm_black="#1e2030"
-thm_gray="#363a4f"
-thm_magenta="#c6a0f6"
+
+thm_rosewater="#f4dbd6"
+thm_flamingo="#f0c6c6"
 thm_pink="#f5bde6"
+thm_mauve="#c6a0f6"
 thm_red="#ed8796"
-thm_green="#a6da95"
+thm_maroon="#ee99a0"
+thm_peach="#f5a97f"
 thm_yellow="#eed49f"
+thm_green="#a6da95"
+thm_teal="#8bd5ca"
+thm_sky="#91d7e3"
+thm_sapphire="#7dc4e4"
 thm_blue="#8aadf4"
-thm_orange="#f5a97f"
-thm_black4="#5b6078"
+thm_lavender="#b7bdf8"
+
+thm_surface2="#5b6078"
+thm_surface1="#494d64"
+thm_surface0="#363a4f"
+thm_overlay2="#939ab7"
+thm_overlay1="#8087a2"
+thm_overlay0="#6e738d"
+
+thm_black="#1e2030" # mantle
+thm_gray="#363a4f" # surface 0
+
+# DEPRECATED, use sky instead
+thm_cyan="${thm_sky}"
+# DEPRECATED, use mauve instead
+thm_magenta="${thm_mauve}"
+# DEPRECATED, use peach instead
+thm_orange="${thm_peach}"
+# DEPRECATED, use surface2 instead
+thm_black4="${thm_surface2}"

--- a/themes/catppuccin_mocha.tmuxtheme
+++ b/themes/catppuccin_mocha.tmuxtheme
@@ -2,16 +2,40 @@
 # WARNING: hex colors can't contain capital letters
 
 # --> Catppuccin (Mocha)
+# Base colors
 thm_bg="#1e1e2e"
 thm_fg="#cdd6f4"
-thm_cyan="#89dceb"
-thm_black="#181825"
-thm_gray="#313244"
-thm_magenta="#cba6f7"
+
+thm_rosewater="#f5e0dc"
+thm_flamingo="#f2cdcd"
 thm_pink="#f5c2e7"
+thm_mauve="#cba6f7"
 thm_red="#f38ba8"
-thm_green="#a6e3a1"
+thm_maroon="#eba0ac"
+thm_peach="#fab387"
 thm_yellow="#f9e2af"
+thm_green="#a6e3a1"
+thm_teal="#94e2d5"
+thm_sky="#89dceb"
+thm_sapphire="#74c7ec"
 thm_blue="#89b4fa"
-thm_orange="#fab387"
-thm_black4="#585b70"
+thm_lavender="#b4befe"
+
+thm_surface2="#585b70"
+thm_surface1="#45475a"
+thm_surface0="#313244"
+thm_overlay2="#9399b2"
+thm_overlay1="#7f849c"
+thm_overlay0="#6c7086"
+
+thm_black="#181825" # mantle
+thm_gray="#313244" # surface 0
+
+# DEPRECATED, use sky instead
+thm_cyan="${thm_sky}"
+# DEPRECATED, use mauve instead
+thm_magenta="${thm_mauve}"
+# DEPRECATED, use peach instead
+thm_orange="${thm_peach}"
+# DEPRECATED, use surface2 instead
+thm_black4="${thm_surface2}"

--- a/tmux.tera
+++ b/tmux.tera
@@ -10,16 +10,40 @@ whiskers:
 # WARNING: hex colors can't contain capital letters
 
 # --> Catppuccin ({{ flavor.identifier | capitalize }})
+# Base colors
 thm_bg="#{{ palette.base.hex | lower }}"
 thm_fg="#{{ palette.text.hex | lower }}"
-thm_cyan="#{{ palette.sky.hex| lower }}"
-thm_black="#{{ palette.mantle.hex | lower }}"
-thm_gray="#{{ palette.surface0.hex | lower }}"
-thm_magenta="#{{ palette.mauve.hex | lower }}"
+
+thm_rosewater="#{{ palette.rosewater.hex | lower }}"
+thm_flamingo="#{{ palette.flamingo.hex | lower }}"
 thm_pink="#{{ palette.pink.hex | lower }}"
+thm_mauve="#{{ palette.mauve.hex | lower }}"
 thm_red="#{{ palette.red.hex | lower }}"
-thm_green="#{{ palette.green.hex | lower }}"
+thm_maroon="#{{ palette.maroon.hex | lower }}"
+thm_peach="#{{ palette.peach.hex | lower }}"
 thm_yellow="#{{ palette.yellow.hex | lower }}"
+thm_green="#{{ palette.green.hex | lower }}"
+thm_teal="#{{ palette.teal.hex | lower }}"
+thm_sky="#{{ palette.sky.hex | lower }}"
+thm_sapphire="#{{ palette.sapphire.hex | lower }}"
 thm_blue="#{{ palette.blue.hex | lower }}"
-thm_orange="#{{ palette.peach.hex | lower }}"
-thm_black4="#{{ palette.surface2.hex | lower }}"
+thm_lavender="#{{ palette.lavender.hex | lower }}"
+
+thm_surface2="#{{ palette.surface2.hex | lower }}"
+thm_surface1="#{{ palette.surface1.hex | lower }}"
+thm_surface0="#{{ palette.surface0.hex | lower }}"
+thm_overlay2="#{{ palette.overlay2.hex | lower }}"
+thm_overlay1="#{{ palette.overlay1.hex | lower }}"
+thm_overlay0="#{{ palette.overlay0.hex | lower }}"
+
+thm_black="#{{ palette.mantle.hex | lower }}" # mantle
+thm_gray="#{{ palette.surface0.hex | lower }}" # surface 0
+
+# DEPRECATED, use sky instead
+thm_cyan="${thm_sky}"
+# DEPRECATED, use mauve instead
+thm_magenta="${thm_mauve}"
+# DEPRECATED, use peach instead
+thm_orange="${thm_peach}"
+# DEPRECATED, use surface2 instead
+thm_black4="${thm_surface2}"

--- a/window/window_current_format.sh
+++ b/window/window_current_format.sh
@@ -2,7 +2,7 @@ show_window_current_format() {
   local number color background text fill current_window_format
 
   number="#I"
-  color=$(get_tmux_option "@catppuccin_window_current_color" "$thm_orange")
+  color=$(get_tmux_option "@catppuccin_window_current_color" "$thm_peach")
   background=$(get_tmux_option "@catppuccin_window_current_background" "$thm_bg")
   text="$(get_tmux_option "@catppuccin_window_current_text" "#{b:pane_current_path}")" # use #W for application instead of directory
   fill="$(get_tmux_option "@catppuccin_window_current_fill" "number")"                 # number, all, none


### PR DESCRIPTION
This change adds the full palette from https://catppuccin.com/palette, which can be used for customisation