### PR TITLE
fix(ci): disable release-please draft releases

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,7 +6,7 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "draft": true
+      "draft": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
When a release is a draft release-please can't find it, see https://github.com/googleapis/release-please/issues/1650 for more info.