### PR TITLE
refactor: `@catppuccin_flavour` -> `@catppuccin_flavor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ set -g @plugin 'tmux-plugins/tpm'
 3. (Optional) Set your preferred flavor, it defaults to `"mocha"`:
 
 ```bash
-set -g @catppuccin_flavour 'mocha' # latte,frappe, macchiato or mocha
+set -g @catppuccin_flavor 'mocha' # latte,frappe, macchiato or mocha
 ```
 
 ### Manual

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -50,7 +50,7 @@ main() {
   # NOTE: For backwards compatibility remove before 1.0.0
   if [ -z "$theme" ]; then
     theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
-    tmux_echo "catppuccin warning: @catppuccin_flavour has been deprecated use @catppuccin_flavour" 103
+    tmux_echo "catppuccin warning: \\\"@catppuccin_flavour\\\" has been deprecated use \\\"@catppuccin_flavor\\\"" 103
   fi
 
   # NOTE: Pulling in the selected theme by the theme that's being set as local

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -47,7 +47,8 @@ main() {
 
   theme="$(get_tmux_batch_option "@catppuccin_flavor" "")"
 
-  # NOTE: For backwards compatibility remove before 1.0.0
+  # NOTE: For backwards compatibility remove before 1.0.0 and set default for
+  # `@catppuccin_flavor` from `""` to `"mocha"`
   if [ -z "$theme" ]; then
     theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
     tmux_echo "catppuccin warning: \\\"@catppuccin_flavour\\\" has been deprecated use \\\"@catppuccin_flavor\\\"" 103

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -27,7 +27,7 @@ main() {
 
   # Batch options for loading the colorscheme and everyting before
   add_tmux_batch_option "@catppuccin_custom_plugin_dir"
-  add_tmux_batch_option "@catppuccin_flavour"
+  add_tmux_batch_option "@catppuccin_flavor"
 
   run_tmux_batch_commands
 
@@ -44,7 +44,15 @@ main() {
   local color_interpolation=()
   local color_values=()
   local temp
-  theme="$(get_tmux_batch_option "@catppuccin_flavour" "mocha")"
+
+  theme="$(get_tmux_batch_option "@catppuccin_flavor" "")"
+
+  # NOTE: For backwards compatibility remove before 1.0.0
+  if [ -z "$theme" ]; then
+    theme="$(get_tmux_option "@catppuccin_flavour" "mocha")"
+    tmux_echo "catppuccin warning: @catppuccin_flavour has been deprecated use @catppuccin_flavour" 103
+  fi
+
   # NOTE: Pulling in the selected theme by the theme that's being set as local
   # variables.
   # https://github.com/dylanaraps/pure-sh-bible#parsing-a-keyval-file

--- a/utils/module_utils.sh
+++ b/utils/module_utils.sh
@@ -35,9 +35,9 @@ load_modules() {
 
     if [[ -z "${module_name/ }" ]]; then
       if [[ -z "${modules_list/ }" ]]; then
-        tmux_echo "catppuccin warning: a module list has only white space, to remove all modules set it to \"null\"" 100
+        tmux_echo "catppuccin warning: a module list has only white space, to remove all modules set it to \\\"null\\\"" 100
       else
-        tmux_echo "catppuccin warning: a module list with value \"$modules_list\" has leading/trailing whitespace" 101
+        tmux_echo "catppuccin warning: a module list with value \\\"$modules_list\\\" has leading/trailing whitespace" 101
       fi
       continue
     fi


### PR DESCRIPTION
Most catppuccin ports have adopted the flavor spelling.

`@catppuccin_flavour` is still available but no longer documented and `@catppuccin_flavor` takes priority.