### PR TITLE
feat: error/warning messages on first load

### DIFF
--- a/utils/module_utils.sh
+++ b/utils/module_utils.sh
@@ -35,14 +35,14 @@ load_modules() {
 
     if [[ -z "${module_name/ }" ]]; then
       if [[ -z "${modules_list/ }" ]]; then
-        tmux_echo "catppuccin warning: a module list has only white space, to remove all modules set it to \"null\""
+        tmux_echo "catppuccin warning: a module list has only white space, to remove all modules set it to \"null\"" 100
       else
-        tmux_echo "catppuccin warning: a module list with value \"$modules_list\" has leading/trailing whitespace"
+        tmux_echo "catppuccin warning: a module list with value \"$modules_list\" has leading/trailing whitespace" 101
       fi
       continue
     fi
 
-    tmux_echo "catppuccin warning: module $module_name not found"
+    tmux_echo "catppuccin warning: module $module_name not found" 102
 
 
   done

--- a/utils/tmux_utils.sh
+++ b/utils/tmux_utils.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 tmux_echo() {
-  local message="$1"
-  tmux run-shell "echo '$message'"
+  local hook
+  hook="after-new-session[$2]"
+
+  tmux set-hook -g "$hook" "run-shell 'echo \"$1\"'; set-hook -gu \"$hook\""
 }
 
 get_tmux_option() {


### PR DESCRIPTION
`tmux_echo` now uses hooks this allows it to print on the first load. To cleanup the hooks every hook gets a _unique_ number/index, this is _not_ enforced.