### PR TITLE
refactor: `catppuccin_window_status{_icon}_enable`->`catppuccin_windo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,19 +120,12 @@ Values:
 
 #### Enable window status:
 ```sh
-set -g @catppuccin_window_status_enable "no"
+set -g @catppuccin_window_status "no"
 ```
 Values:
-- yes - this will enable the window status part
 - no - this will disable the window status part
-
-#### Enable window status icons instead of text:
-```sh
-set -g @catppuccin_window_status_icon_enable "yes"
-```
-Values:
-- yes - this will replace the windows status text with icons
-- no - this will keep the windows status in text format
+- icon - this will replace the windows status text with icons
+- text - this will keep the windows status in text format
 
 #### Override windows status icons
 ```sh

--- a/builder/window_builder.sh
+++ b/builder/window_builder.sh
@@ -10,7 +10,26 @@ build_window_format() {
   local text="$4"
   local fill="$5"
 
-  if [ "$window_status_enable" = "yes" ]; then
+  # NOTE: For backwards compatibility remove before 1.0.0 and update default for
+  # `@catppuccin_window_status`
+  if [ -z "$window_status" ]; then
+    window_status_enable="$(get_tmux_option "@catppuccin_window_status_enable" "no")"
+    tmux_echo "catppuccin warning: \\\"@catppuccin_window_status_enable\\\" and \\\"@catppuccin_window_status_icon_enable\\\" has been replaced by\n\t \
+      \\\"@catppuccin_window_status\\\" with the options \\\"no\\\", \\\"icon\\\" and \\\"text\\\"" 104
+
+    if [ "$window_status_enable" = "yes" ]; then
+      window_status_icon_enable="$(get_tmux_option "@catppuccin_window_status_icon_enable" "yes")"
+      if [ "$window_status_icon_enable" = "yes" ]; then
+        window_status="icon"
+      else
+        window_status="text"
+      fi
+    else
+      window_status="no"
+    fi
+  fi
+
+  if [ ! "$window_status" = "no" ]; then
     local icon
     icon="$(build_window_icon)"
     text="$text$icon"
@@ -136,8 +155,8 @@ build_window_icon() {
     custom_icon_window_activity=$(get_tmux_batch_option "@catppuccin_icon_window_activity" "󱅫")
     custom_icon_window_bell=$(get_tmux_batch_option "@catppuccin_icon_window_bell" "󰂞")
 
-    if [ "$window_status_icon_enable" = "yes" ]; then
-      # #!~[*-]MZ
+    if [ "$window_status" = "icon" ]; then
+      # icon order: #!~[*-]MZ
       show_window_status=""
       show_window_status+="#{?window_activity_flag,$(prepend_separator "${custom_icon_window_activity}"),}"
       show_window_status+="#{?window_bell_flag,$(prepend_separator "${custom_icon_window_bell}"),}"
@@ -146,9 +165,7 @@ build_window_icon() {
       show_window_status+="#{?window_last_flag,$(prepend_separator "${custom_icon_window_last}"),}"
       show_window_status+="#{?window_marked_flag,$(prepend_separator "${custom_icon_window_mark}"),}"
       show_window_status+="#{?window_zoomed_flag,$(prepend_separator "${custom_icon_window_zoom}"),}"
-    fi
-
-    if [ "$window_status_icon_enable" = "no" ]; then
+    elif [ "$window_status" = "text" ]; then
       show_window_status=" #F"
     fi
   fi

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -85,7 +85,7 @@ main() {
   add_tmux_batch_option "@catppuccin_window_right_separator"
   add_tmux_batch_option "@catppuccin_window_middle_separator"
   add_tmux_batch_option "@catppuccin_window_number_position"
-  add_tmux_batch_option "@catppuccin_window_status_enable"
+  add_tmux_batch_option "@catppuccin_window_status"
   add_tmux_batch_option "@catppuccin_status_left_separator"
   add_tmux_batch_option "@catppuccin_status_right_separator"
   add_tmux_batch_option "@catppuccin_status_connect_separator"
@@ -170,7 +170,11 @@ main() {
   window_right_separator=$(get_tmux_batch_option "@catppuccin_window_right_separator" "█")
   window_middle_separator=$(get_tmux_batch_option "@catppuccin_window_middle_separator" "█ ")
   window_number_position=$(get_tmux_batch_option "@catppuccin_window_number_position" "left") # right, left
-  window_status_enable=$(get_tmux_batch_option "@catppuccin_window_status_enable" "no")       # right, left
+
+  # NOTE: update default to `"no"` when removing the backwards compatibility for
+  # `@catppuccin_window_status_enable` and
+  # `@catppuccin_window_status_icon_enable` in ./builder/window_builder.sh
+  window_status=$(get_tmux_batch_option "@catppuccin_window_status" "") # no, icon, text
 
   window_format=$(load_modules "window_default_format" "$modules_custom_path" "$modules_window_path")
   setw window-status-format "$(do_color_interpolation "$window_format")"

--- a/utils/tmux_utils.sh
+++ b/utils/tmux_utils.sh
@@ -4,7 +4,7 @@ tmux_echo() {
   local hook
   hook="after-new-session[$2]"
 
-  tmux set-hook -g "$hook" "run-shell 'echo \"$1\"'; set-hook -gu \"$hook\""
+  tmux set-hook -g "$hook" "run-shell 'echo -e \"$1\"'; set-hook -gu \"$hook\""
 }
 
 get_tmux_option() {


### PR DESCRIPTION
…w_status`

`@catppuccin_window_status_enable` and
`@catppuccin_window_status_icon_enable` have been merged into `@catppuccin_window_status`.

Current configurations will remain to work but receive a warning message of the change.