### PR TITLE
docs: add clarifying note in the README about null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,15 @@ This is a diagram of how the theme is split between its components.
 ## Configuration options
 
 All flavors support certain levels of customization that match our [Catppuccin
-Style Guide][style-guide]. To add these customizations, add any of the following
-options to your Tmux configuration.
+Style Guide][style-guide]. To add these customizations, you may add any of the
+following options to your Tmux configuration.
+
+If you want to set a text-based customization to an emtpy string, use `null` to
+do so. For instance:
+
+```sh
+set -g @catppuccin_icon_window_last "null"
+```
 
 ### Window
 

--- a/README.md
+++ b/README.md
@@ -341,16 +341,6 @@ set -g @catppuccin_[module_name]_color "color"
 set -g @catppuccin_[module_name]_text "text"
 ```
 
-#### Removing a specific module option
-```sh
-set -g @catppuccin_[module_name]_[option] "null"
-```
-This is for the situation where you want to remove the icon from a module.
-Ex:
-```sh
-set -g @catppuccin_date_time_icon "null"
-```
-
 ### Battery module
 
 #### Requirements


### PR DESCRIPTION
This took me way too long to realize there even is a way to "disable" (set to empty) a customization without changing the code. This PR addresses the issue and adds a note at the top of the customization section that every text-based customization may be null.