### PR TITLE
fix(kube): escape env var

### DIFF
--- a/status/kube.sh
+++ b/status/kube.sh
@@ -16,7 +16,7 @@ show_kube() {
   context_color=$(get_tmux_batch_option "@catppuccin_kube_context_color" "#{thm_red}")
   namespace_color=$(get_tmux_batch_option "@catppuccin_kube_namespace_color" "#{thm_cyan}")
   symbol_enabled=${KUBE_TMUX_SYMBOL_ENABLE:-false}
-  text=$(get_tmux_batch_option "@catppuccin_kube_text" "#(KUBE_TMUX_SYMBOL_ENABLE=$symbol_enabled ${TMUX_PLUGIN_MANAGER_PATH}kube-tmux/kube.tmux 250 '$context_color' '$namespace_color')")
+  text=$(get_tmux_batch_option "@catppuccin_kube_text" "#(KUBE_TMUX_SYMBOL_ENABLE=$symbol_enabled \${TMUX_PLUGIN_MANAGER_PATH}kube-tmux/kube.tmux 250 '$context_color' '$namespace_color')")
 
   module=$(build_status_module "$index" "$icon" "$color" "$text")
 


### PR DESCRIPTION
Need this to be interpreted when tmux status is updated rather than when this script executes as the value is set in the tmux env rather than the current shell

resolves #301 