### PR TITLE
Update README.md mistake on selecting flavour

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ set -g @plugin 'tmux-plugins/tpm'
 3. (Optional) Set your preferred flavor, it defaults to `"mocha"`:
 
 ```bash
-set -g @catppuccin_flavor 'mocha' # latte,frappe, macchiato or mocha
+set -g @catppuccin_flavour 'mocha' # latte,frappe, macchiato or mocha
 ```
 
 ### Manual


### PR DESCRIPTION
The docs say that the flavour is picked with @catppuccin_flavor, but it's really done with @catppuccin_flavour