### PR TITLE
chore: replace `@message_background` with an hidden variable

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -7,19 +7,19 @@ set status-right-length "100"
 
 %if "#{==:#{@catppuccin_status_background},default}"
   set -gF status-style "bg=#{@thm_bg},fg=#{@thm_fg}"
-  set -gF @message_background "#{@thm_surface_0}"
+  %hidden CTP_MESSAGE_BACKGROUND="#{@thm_surface_0}"
 %elif "#{==:#{@catppuccin_status_background},none}"
-  set -g status-style "default"
-  set -g @message_background "default"
+  %hidden CTP_MESSAGE_BACKGROUND="default"
+  set -g status-style "$CTP_MESSAGE_BACKGROUND"
 %else
   # Treat @catppuccin_status_background as a format string.
-  set -gF @message_background "#{E:@catppuccin_status_background}"
-  set -gF status-style "bg=#{@message_background},fg=#{@thm_fg}"
+  %hidden CTP_MESSAGE_BACKGROUND="#{E:@catppuccin_status_background}"
+  set -gF status-style "bg=$CTP_MESSAGE_BACKGROUND,fg=#{@thm_fg}"
 %endif
 
 # messages
-set -gF message-style "fg=#{@thm_sky},bg=#{@message_background},align=centre"
-set -gF message-command-style "fg=#{@thm_sky},bg=#{@message_background},align=centre"
+set -gF message-style "fg=#{@thm_sky},bg=$CTP_MESSAGE_BACKGROUND,align=centre"
+set -gF message-command-style "fg=#{@thm_sky},bg=$CTP_MESSAGE_BACKGROUND,align=centre"
 
 # menu
 set -gF menu-style "#{E:@catppuccin_menu_style}"


### PR DESCRIPTION
This does not add extra option when using `tmux show -g` (or unsetting it later) and does not require expansion with `#{@`.