### PR TITLE
chore: improve testing

### DIFF
--- a/tests/application_module.sh
+++ b/tests/application_module.sh
@@ -8,4 +8,12 @@ source "${script_dir}/helpers.sh"
 tmux source "${script_dir}/../catppuccin_options_tmux.conf"
 tmux source "${script_dir}/../catppuccin_tmux.conf"
 
-print_option @catppuccin_status_application | sed -E 's/\b(bash|fish|zsh)\b/<application>/'
+application_text=$(get_option @catppuccin_application_text)
+
+print_option @catppuccin_status_application | grep -q "$application_text" ||
+  echo "@catppuccin_status_application expanded @catppuccin_application_text more than once"
+
+print_option @catppuccin_status_application | grep -q "@thm_" &&
+  echo "@catppuccin_status_application did not expand all colors"
+
+print_option E:@catppuccin_status_application | sed -E 's/\b(bash|fish|zsh)\b/<application>/'

--- a/tests/application_module_expected.txt
+++ b/tests/application_module_expected.txt
@@ -1,1 +1,1 @@
-@catppuccin_status_application #[fg=#f5c2e7,bg=default,nobold,nounderscore,noitalics] #[fg=#11111b,bg=#f5c2e7] #[fg=#cdd6f4,bg=#45475a,nobold] <application>#[fg=#45475a,bg=default]█
+E:@catppuccin_status_application #[fg=#f5c2e7,bg=default,nobold,nounderscore,noitalics] #[fg=#11111b,bg=#f5c2e7] #[fg=#cdd6f4,bg=#45475a,nobold] <application>#[fg=#45475a,bg=default]█

--- a/tests/default_options.sh
+++ b/tests/default_options.sh
@@ -8,6 +8,6 @@ source "${script_dir}/helpers.sh"
 tmux source "${script_dir}/../catppuccin_options_tmux.conf"
 tmux source "${script_dir}/../catppuccin_tmux.conf"
 
-print_option @catppuccin_flavor
-print_option @catppuccin_menu_selected_style
-print_option @catppuccin_pane_active_border_style
+print_option E:@catppuccin_flavor
+print_option E:@catppuccin_menu_selected_style
+print_option E:@catppuccin_pane_active_border_style

--- a/tests/default_options_expected.txt
+++ b/tests/default_options_expected.txt
@@ -1,3 +1,3 @@
-@catppuccin_flavor mocha
-@catppuccin_menu_selected_style fg=#313244,bg=#f9e2af
-@catppuccin_pane_active_border_style fg=#b4befe
+E:@catppuccin_flavor mocha
+E:@catppuccin_menu_selected_style fg=#313244,bg=#f9e2af
+E:@catppuccin_pane_active_border_style fg=#b4befe

--- a/tests/harness.sh
+++ b/tests/harness.sh
@@ -123,6 +123,11 @@ run_test() {
   local output
   # shellcheck disable=SC1090
   output=$(source "${test_script}")
+  test_exit_code="$?"
+
+  if test $test_exit_code -ne 0; then
+    die "\n${RED}Test ${script_name} exited with code $test_exit_code ${NOFORMAT}"
+  fi
 
   echo -e "${output}" | diff -aB --color=${DIFFCOLORS} "${expected_output}" -
 

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 
+# Returns the value of given tmux option.
+# First argument is the option name, e.g. @catppuccin_flavor.
+#
+# Usage: `get_option @catppuccin_flavor`
+# Would return: `mocha`
+#
+# The option is given as a format string.
+get_option() {
+  local option
+  option=$1
+
+  tmux display-message -p "#{${option}}"
+}
+
 # Prints the given tmux option to stdout.
 # First argument is the option name, e.g. @catppuccin_flavor.
 #
-# Usage: `print-option @catppuccin_flavor`
+# Usage: `print_option @catppuccin_flavor`
 # Would print: `@catppuccin_flavor mocha`
 #
-# The variable given is expanded as a format string.
+# The option is given as a format string.
 print_option() {
   local option
   option=$1
 
   printf "\n%s " "${option}"
-  tmux display-message -p "#{E:${option}}"
+  get_option "$option"
 }


### PR DESCRIPTION
- fail tests if test scripts exit's with none 0 code
- don't expand option by default
- check all if colors are expanded
- check if module text is not expanded