### PR TITLE
feat: idea window builder

### DIFF
--- a/builder/window_builder.conf
+++ b/builder/window_builder.conf
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+%if "#{==:$window_type,default}"
+  %hidden CTP_OPTION=""
+  %hidden TMUX_OPTION=""
+%else
+  %hidden CTP_OPTION="${window_type}_"
+  %hidden TMUX_OPTION="${window_type}-"
+
+  # use options from default unless set otherwise
+  set -ogqF @catppuccin_window_${CTP_OPTION}status_style "#{E:@catppuccin_window_status_style}"
+  set -ogqF @catppuccin_window_${CTP_OPTION}status_fg "#{E:@catppuccin_window_status_fg}"
+  set -ogqF @catppuccin_window_${CTP_OPTION}status_bg "#{E:@catppuccin_window_status_bg}"
+
+  # set -ogq @catppuccin_window_${CTP_OPTION}left_separator "#{E:@catppuccin_window_left_separator}"
+  # set -ogq @catppuccin_window_${CTP_OPTION}right_separator "#{E:@catppuccin_window_right_separator}"
+  # set -ogq @catppuccin_window_${CTP_OPTION}middle_separator "#{E:@catppuccin_window_middle_separator}"
+  # set -ogq @catppuccin_window_${CTP_OPTION}number_position "#{E:@catppuccin_window_number_position}"
+%endif
+
+# don't style it if style is empty
+%if "#{==:#{@catppuccin_window_${CTP_OPTION}status_style},default}"
+  %hidden CTP_BG="@catppuccin_window_${CTP_OPTION}status_bg"
+  %hidden CTP_FG="@catppuccin_window_${CTP_OPTION}status_fg"
+
+  set -gF "window-status-${TMUX_OPTION}style" "bg=#{$CTP_BG},fg=#{$CTP_FG}"
+  set -gF "window-status-${TMUX_OPTION}format" "#[bg=#{$CTP_FG},fg=#{$CTP_BG}] ##I #[bg=#{$CTP_BG},fg=#{@thm_fg}] ##T "
+%endif

--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -23,12 +23,29 @@ set -ogq @catppuccin_pane_right_separator "█"
 set -ogq @catppuccin_pane_number_position "left" # right, left
 
 # Window options
-set -ogq @catppuccin_window_separator ""
+set -ogq @catppuccin_window_status_style "default"
+set -ogq @catppuccin_window_status_bg "#{@thm_bg}"
+set -ogq @catppuccin_window_status_fg "#{@thm_overlay_2}"
 set -ogq @catppuccin_window_left_separator "█"
 set -ogq @catppuccin_window_right_separator "█"
 set -ogq @catppuccin_window_middle_separator "█"
 set -ogq @catppuccin_window_number_position "left"
-set -ogq @catppuccin_window_status_style "default" # default, or none
+
+set -ogq @catppuccin_window_current_status_bg "#{@thm_surface_1}"
+set -ogq @catppuccin_window_current_status_fg "#{@thm_peach}"
+set -ogq @catppuccin_window_activity_status_bg "#{@thm_yellow}"
+set -ogq @catppuccin_window_activity_status_fg "#{@thm_crust}"
+set -ogq @catppuccin_window_bell_status_bg "#{E:@catppuccin_window_activity_status_bg}"
+set -ogq @catppuccin_window_bell_status_fg "#{E:@catppuccin_window_activity_status_fg}"
+
+# Window icons
+set -ogq @catppuccin_icon_window_last "󰖰"
+set -ogq @catppuccin_icon_window_current "󰖯"
+set -ogq @catppuccin_icon_window_zoom "󰁌"
+set -ogq @catppuccin_icon_window_mark "󰃀"
+set -ogq @catppuccin_icon_window_silent "󰂛"
+set -ogq @catppuccin_icon_window_activity "󱅫"
+set -ogq @catppuccin_icon_window_bell "󰂞"
 
 # Status line options
 set -ogq @catppuccin_status_left_separator ""

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -43,16 +43,25 @@ set -wF popup-border-style "fg=#{@thm_surface_1}"
 %endif
 
 # window status
-%if "#{==:#{@catppuccin_window_status_style},default}"
-set -gF window-status-style "bg=#{@thm_mantle},fg=#{@thm_subtext_1}"
-set -gF window-status-current-style "bg=#{@thm_surface_1},fg=#{@thm_peach}"
-set -gF window-status-activity-style "bg=#{@thm_yellow},fg=#{@thm_crust}"
-set -gF window-status-bell-style "bg=#{@thm_yellow},fg=#{@thm_crust}"
+# %if "#{==:#{@catppuccin_window_status_style},default}"
+# set -gF window-status-style "bg=#{@thm_mantle},fg=#{@thm_subtext_1}"
+# set -gF window-status-current-style "bg=#{@thm_surface_1},fg=#{@thm_peach}"
+# set -gF window-status-activity-style "bg=#{@thm_yellow},fg=#{@thm_crust}"
+# set -gF window-status-bell-style "bg=#{@thm_yellow},fg=#{@thm_crust}"
+#
+# # window status formats
+# set -gF window-status-format "#[bg=#{@thm_overlay_2},fg=#{@thm_crust}] ##I #[bg=#{@thm_bg},fg=#{@thm_fg}] ##T "
+# set -gF window-status-current-format "#[bg=#{@thm_peach},fg=#{@thm_crust}] ##I #[bg=#{@thm_surface_1},fg=#{@thm_fg}] ##T "
+# %endif
+%hidden window_type="default"
+source -F "#{d:current_file}/builder/window_builder.conf"
+%hidden window_type="current"
+source -F "#{d:current_file}/builder/window_builder.conf"
+%hidden window_type="active"
+source -F "#{d:current_file}/builder/window_builder.conf"
+%hidden window_type="bell"
+source -F "#{d:current_file}/builder/window_builder.conf"
 
-# window status formats
-set -gF window-status-format "#[bg=#{@thm_overlay_2},fg=#{@thm_crust}] ##I #[bg=#{@thm_bg},fg=#{@thm_fg}] ##T "
-set -gF window-status-current-format "#[bg=#{@thm_peach},fg=#{@thm_crust}] ##I #[bg=#{@thm_surface_1},fg=#{@thm_fg}] ##T "
-%endif
 
 # modes
 set -wF mode-style "fg=#{@thm_pink},bg=#{@thm_surface_2},bold"


### PR DESCRIPTION
a rough idea of how we could do window implementations.
Still has some issues 

```conf
%hidden window_type="default"
source -F "#{d:current_file}/builder/window_builder.conf"
%hidden window_type="current"
source -F "#{d:current_file}/builder/window_builder.conf"
%hidden window_type="active"
source -F "#{d:current_file}/builder/window_builder.conf"
%hidden window_type="bell"
source -F "#{d:current_file}/builder/window_builder.conf"
```
does not work for example. would need a file per `window_type` where you source the builder like done with application.

prefer this method over predefining a few styles this gives users complete control to overwrite anything while allowing for simple examples/presets.