### PR TITLE
feat(status/window): icons

### DIFF
--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -38,14 +38,14 @@ set -ogq @catppuccin_window_current_background "#{@thm_peach}"
 set -ogq @catppuccin_window_current_text " ##T"
 set -ogq @catppuccin_window_number_position "left"
 set -ogq @catppuccin_window_status "icon"
-set -ogq @catppuccin_window_flags_icon_last " 󰖰"
-set -ogq @catppuccin_window_flags_icon_current " 󰖯"
-set -ogq @catppuccin_window_flags_icon_zoom " 󰁌"
-set -ogq @catppuccin_window_flags_icon_mark " 󰃀"
-set -ogq @catppuccin_window_flags_icon_silent " 󰂛"
-set -ogq @catppuccin_window_flags_icon_activity " 󱅫"
-set -ogq @catppuccin_window_flags_icon_bell " 󰂞"
-# icon order: #!~[*-]MZ
+set -ogq @catppuccin_window_flags_icon_last " 󰖰" # -
+set -ogq @catppuccin_window_flags_icon_current " 󰖯" # *
+set -ogq @catppuccin_window_flags_icon_zoom " 󰁌" # Z
+set -ogq @catppuccin_window_flags_icon_mark " 󰃀" # M
+set -ogq @catppuccin_window_flags_icon_silent " 󰂛" # ~
+set -ogq @catppuccin_window_flags_icon_activity " 󱅫" # #
+set -ogq @catppuccin_window_flags_icon_bell " 󰂞" # !
+# Matches icon order when using `#F` (`#!~[*-]MZ`)
 set -ogq @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},}"
 
 # Status line options

--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -37,6 +37,16 @@ set -ogq @catppuccin_window_current_color "#{@thm_surface_1}"
 set -ogq @catppuccin_window_current_background "#{@thm_peach}"
 set -ogq @catppuccin_window_current_text " ##T"
 set -ogq @catppuccin_window_number_position "left"
+set -ogq @catppuccin_window_status "icon"
+set -ogq @catppuccin_window_flags_icon_last " 󰖰"
+set -ogq @catppuccin_window_flags_icon_current " 󰖯"
+set -ogq @catppuccin_window_flags_icon_zoom " 󰁌"
+set -ogq @catppuccin_window_flags_icon_mark " 󰃀"
+set -ogq @catppuccin_window_flags_icon_silent " 󰂛"
+set -ogq @catppuccin_window_flags_icon_activity " 󱅫"
+set -ogq @catppuccin_window_flags_icon_bell " 󰂞"
+# icon order: #!~[*-]MZ
+set -ogq @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},}"
 
 # Status line options
 set -ogq @catppuccin_status_left_separator ""

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -6,10 +6,15 @@ source -F "#{d:current_file}/status/clima.conf"
 source -F "#{d:current_file}/status/cpu.conf"
 source -F "#{d:current_file}/status/date_time.conf"
 source -F "#{d:current_file}/status/directory.conf"
+source -F "#{d:current_file}/status/gitmux.conf"
 source -F "#{d:current_file}/status/host.conf"
+source -F "#{d:current_file}/status/kube.conf"
 source -F "#{d:current_file}/status/load.conf"
 source -F "#{d:current_file}/status/pomodoro_plus.conf"
 source -F "#{d:current_file}/status/session.conf"
+source -F "#{d:current_file}/status/uptime.conf"
+source -F "#{d:current_file}/status/user.conf"
+source -F "#{d:current_file}/status/weather.conf"
 
 set status-left-length "100"
 set status-right-length "100"
@@ -57,21 +62,21 @@ set -wF pane-border-style "#{E:@catppuccin_pane_border_style}"
       "#[fg=#{@thm_fg},bg=#{@thm_surface_0}]#{@catppuccin_pane_middle_separator}"
     set -g @_ctp_p_right \
       "#[fg=#{@thm_surface_0},bg=default]#{@catppuccin_pane_middle_separator}"
-    
+
     set -g @_ctp_p_number \
       "#[fg=#{@thm_fg},bg=#{@thm_surface_0}]#{pane_index}"
     set -g @_ctp_p_text \
       "#[fg=#{@thm_fg},bg=#{@thm_surface_0}]#{E:@catppuccin_pane_default_text}"
 
   %elif "#{==:#{@catppuccin_pane_default_fill},all}"
-   
+
     set -g @_ctp_p_left \
       "#[fg=#{E:@catppuccin_pane_color},bg=default]#{@catppuccin_pane_left_separator}"
     set -g @_ctp_p_middle \
       "#[fg=#{E:@catppuccin_pane_background_color},bg=#{E:@catppuccin_pane_color}]#{@catppuccin_pane_middle_separator}"
     set -g @_ctp_p_right \
       "#[fg=#{E:@catppuccin_pane_color},bg=default]#{@catppuccin_pane_middle_separator}"
-    
+
     set -g @_ctp_p_number \
       "#[fg=#{E:@catppuccin_pane_background_color},bg=#{E:@catppuccin_pane_color}]#{pane_index}"
     set -g @_ctp_p_text \
@@ -93,7 +98,7 @@ set -wF pane-border-style "#{E:@catppuccin_pane_border_style}"
 
     set -g @_ctp_p_middle \
       "#[fg=#{E:@catppuccin_pane_color},bg=#{E:@catppuccin_pane_background_color}]#{@catppuccin_pane_middle_separator}"
-    
+
     set -g @_ctp_p_number \
       "#[fg=#{E:@catppuccin_pane_background_color},bg=#{E:@catppuccin_pane_color}]#{pane_index}"
     set -g @_ctp_p_text \
@@ -101,6 +106,7 @@ set -wF pane-border-style "#{E:@catppuccin_pane_border_style}"
 
   %endif
 
+  set -agq @_ctp_p_text "@{_ctp_p_flags}"
   %if "#{==:#{@catppuccin_pane_number_position},left}"
     set -wF pane-border-format \
       "#{E:@_ctp_p_left}#{E:@_ctp_p_number}#{E:@_ctp_p_middle}#{E:@_ctp_p_text}#{E:@_ctp_p_right}"
@@ -161,6 +167,15 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
   set -gq @_ctp_w_number ""
   set -gq @_ctp_w_text ""
 
+  %if "#{==:#{@catppuccin_window_status},icon}"
+    set -gqF @_ctp_w_flags "#{E:@catppuccin_window_flags_icon_format}"
+  %elif "#{==:#{@catppuccin_window_status},text}"
+    set -gq @_ctp_w_flags "#F"
+  %else
+    set -gq @_ctp_w_flags ""
+  %endif
+
+
   %if "#{==:#{@catppuccin_window_default_fill},none}"
 
     set -g @_ctp_w_left \
@@ -169,7 +184,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
       "#[fg=#{@thm_surface_0},bg=default]#{@catppuccin_window_middle_separator}"
     set -g @_ctp_w_right \
       "#[fg=#{@thm_surface_0},bg=default]#{@catppuccin_window_right_separator}"
-    
+
     set -g @_ctp_w_number \
       "#[fg=#{@thm_fg},bg=#{@thm_surface_0}]##I"
     set -g @_ctp_w_text \
@@ -203,6 +218,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
     %endif
   %endif
 
+  set -agq @_ctp_w_text "#{@_ctp_w_flags}"
   %if "#{==:#{@catppuccin_window_number_position},left}"
     set -gF window-status-format \
       "#{E:@_ctp_w_left}#{E:@_ctp_w_number}#{E:@_ctp_w_middle}#{E:@_ctp_w_text}#{E:@_ctp_w_right}"
@@ -223,7 +239,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
       "#[fg=#{E:@catppuccin_window_current_color},bg=default]#{@catppuccin_window_current_middle_separator}"
     set -g @_ctp_w_right \
       "#[fg=#{E:@catppuccin_window_current_color},bg=default]#{@catppuccin_window_current_right_separator}"
-    
+
     set -g @_ctp_w_number \
       "#[fg=#{@thm_fg},bg=#{E:@catppuccin_window_current_color}]##I"
     set -g @_ctp_w_text \
@@ -257,6 +273,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
     %endif
   %endif
 
+  set -agq @_ctp_w_text "#{@_ctp_w_flags}"
   %if "#{==:#{@catppuccin_window_number_position},left}"
     set -gF window-status-current-format \
       "#{E:@_ctp_w_left}#{E:@_ctp_w_number}#{E:@_ctp_w_middle}#{E:@_ctp_w_text}#{E:@_ctp_w_right}"
@@ -266,11 +283,12 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
   %endif
 
   # Cleanup (unset) all of the variables to cleanup.
-  set -ug @_ctp_p_left
-  set -ug @_ctp_p_middle
-  set -ug @_ctp_p_right
-  set -ug @_ctp_p_number
-  set -ug @_ctp_p_text
+  set -ug @_ctp_w_left
+  set -ug @_ctp_w_middle
+  set -ug @_ctp_w_right
+  set -ug @_ctp_w_number
+  set -ug @_ctp_w_text
+  set -ug @_ctp_w_flags
 %endif
 
 # modes

--- a/status/application.conf
+++ b/status/application.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="application"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" ""
+set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_pink}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{pane_current_command}"
 

--- a/status/battery.conf
+++ b/status/battery.conf
@@ -15,7 +15,7 @@ set -ogq @batt_icon_status_discharging "󰂃"
 set -ogq @batt_icon_status_unknown "󰂑"
 set -ogq @batt_icon_status_attached "󱈑"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{battery_icon}"
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{battery_icon} "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{battery_percentage}"
 

--- a/status/clima.conf
+++ b/status/clima.conf
@@ -2,7 +2,7 @@
 # Requires https://github.com/vascomfnunes/tmux-clima
 %hidden MODULE_NAME="clima"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" ""
+set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{clima}"
 

--- a/status/cpu.conf
+++ b/status/cpu.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="cpu"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" ""
+set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
 set -ogq "@catppuccin_${MODULE_NAME}_color" "#{cpu_bg_color}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{cpu_percentage}"
 

--- a/status/date_time.conf
+++ b/status/date_time.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="date_time"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰃰"
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰃰 "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "%Y-%m-%d %H:%M"
 

--- a/status/directory.conf
+++ b/status/directory.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="directory"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" ""
+set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_pink}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{b:pane_current_path}"
 

--- a/status/gitmux.conf
+++ b/status/gitmux.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="gitmux"
 
 # Requires https://github.com/arl/gitmux
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊢"
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊢 "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_green}"
 set -gq "@catppuccin_${MODULE_NAME}_text" '#(gitmux "#{pane_current_path}")'
 

--- a/status/host.conf
+++ b/status/host.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="host"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰒋"
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰒋 "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_mauve}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#H"
 

--- a/status/kube.conf
+++ b/status/kube.conf
@@ -3,7 +3,7 @@
 
 # Requires https://github.com/jonmosco/kube-tmux
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "󱃾"
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "󱃾 "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_blue}"
 set -ogqF "@catppuccin_kube_context_color" "#{@thm_red}"
 set -ogqF "@catppuccin_kube_namespace_color" "#{@thm_sky}"

--- a/status/load.conf
+++ b/status/load.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="load"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊚"
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊚 "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{load_full}"
 

--- a/status/pomodoro_plus.conf
+++ b/status/pomodoro_plus.conf
@@ -2,7 +2,7 @@
 # Requires https://github.com/olimorris/tmux-pomodoro-plus
 %hidden MODULE_NAME="pomodoro_plus"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" ""
+set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_orange}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{pomodoro_status}"
 

--- a/status/session.conf
+++ b/status/session.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="session"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" ""
+set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "##{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#S"
 

--- a/status/uptime.conf
+++ b/status/uptime.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="uptime"
 
-set -ogq @catppuccin_uptime_icon "󰔟"
+set -ogq @catppuccin_uptime_icon "󰔟 "
 set -ogqF @catppuccin_uptime_color "#{@thm_green}"
 set -ogq @catppuccin_uptime_text "#(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')"
 

--- a/status/user.conf
+++ b/status/user.conf
@@ -1,7 +1,7 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="user"
 
-set -ogq @catppuccin_user_icon ""
+set -ogq @catppuccin_user_icon " "
 set -ogqF @catppuccin_user_color "#{@thm_sky}"
 set -ogq @catppuccin_user_text "#(whoami)"
 

--- a/status/weather.conf
+++ b/status/weather.conf
@@ -3,7 +3,7 @@
 
 # Requires https://github.com/xamut/tmux-weather.
 
-set -ogq @catppuccin_weather_icon ""
+set -ogq @catppuccin_weather_icon " "
 set -ogqF @catppuccin_weather_color "#{@thm_yellow}"
 set -ogq @catppuccin_weather_text "#{weather}"
 

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -6,7 +6,7 @@ set -gF "@catppuccin_status_${MODULE_NAME}" \
   "#[fg=#{@catppuccin_${MODULE_NAME}_color},#{@_ctp_connect_color_bg},nobold,nounderscore,noitalics]#{@catppuccin_status_left_separator}"
 
 set -agF "@catppuccin_status_${MODULE_NAME}" \
-    "#[fg=#{@thm_crust},bg=#{@catppuccin_${MODULE_NAME}_color}]#{@catppuccin_${MODULE_NAME}_icon} "
+    "#[fg=#{@thm_crust},bg=#{@catppuccin_${MODULE_NAME}_color}]#{@catppuccin_${MODULE_NAME}_icon}"
 
 set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_color},"
 %if "#{==:#{@catppuccin_status_fill},icon}"


### PR DESCRIPTION
- Adds support for window flags and flag icons
- Moves the spaced from before/after the icons to inside the icon default to save on boiler plate compares in tmux script.
- renames `catppuccin_icon_<icon_name>` to `catppuccin_window_flags_<icon_name>`, is this name to long?

