### PR TITLE
Issue #342: Checking if battery_icon literal helps

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ git clone https://github.com/catppuccin/tmux.git ~/.config/tmux/plugins/catppucc
 ```
 
 2. Add the following line to your `tmux.conf` file:
-    `run ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux`
+   `run ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux`
 3. (Optional) Set your preferred flavor and/or add configuration options as
    listed in [Configuration Options](#configuration-options). These options must be added above the `run ~/.config...` line.
 4. Reload Tmux by either restarting or reloading with `tmux source ~/.tmux.conf`
@@ -79,11 +79,13 @@ git clone https://github.com/catppuccin/tmux.git ~/.config/tmux/plugins/catppucc
 2. Add the Catppuccin plugin:
 
 <!-- x-release-please-start-version -->
+
 ```bash
 set -g @plugin 'catppuccin/tmux#v1.0.1' # See https://github.com/catppuccin/tmux/tags for additional tags
 # ...alongside
 set -g @plugin 'tmux-plugins/tpm'
 ```
+
 <!-- x-release-please-end -->
 
 3. (Optional) Set your preferred flavor, it defaults to `"mocha"`:
@@ -118,16 +120,9 @@ set -gF window-status-format "#[bg=#{@ctp_surface_1},fg=#{@ctp_fg}] ##I ##T "
 set -gF window-status-current-format "#[bg=#{@ctp_mauve},fg=#{@ctp_crust}] ##I ##T "
 ```
 
-### Upgrading from v0.3.0
+### Upgrading from 0.3
 
-If you are upgrading from 0.3.0 to any later versions, please note the following changes:
-
-1. The `status-left` and `status-right` options are no longer controlled by this plugin.
-   You can adjust these manually. See the section on status line modules for more details.
-1. Any custom status line modules may no longer work correctly, and will need to be rewritten
-   to maintain compatibility with newer plugin versions.
-
-The plugin can be pinned to v0.3.0 if desired: `set -g @plugin 'catppuccin/tmux#v0.3.0'`.
+Breaking changes have been introduced since 0.3, to understand how to migrate your configuration, see pinned issue [#291](https://github.com/catppuccin/tmux/issues/291).
 
 ## Recommended Default Configuration
 
@@ -175,13 +170,13 @@ options to your Tmux configuration.
 
 The plugin comes with three window styles built in, these can be customized by setting the `@catppuccin_window_status_style` option. The default is `basic`.
 
-| Option | Effect | Preview |
-| --- | --- | --- |
-| `basic` | Simple styling with blocks. | ![window basic](./assets/window-basic.webp) |
-| `rounded` | Each window is separated with rounded separators. | ![window rounded style](./assets/window-rounded.webp) |
-| `slanted` | Each window is separated with slanted separators. | ![window slanted style](./assets/window-slanted.webp) |
-| `custom` | Custom separators are used. This is required to override the separators! | |
-| `none` | Styling of the window status is completely disabled. | ![window no styling](./assets/window-none.webp) |
+| Option    | Effect                                                                   | Preview                                               |
+| --------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| `basic`   | Simple styling with blocks.                                              | ![window basic](./assets/window-basic.webp)           |
+| `rounded` | Each window is separated with rounded separators.                        | ![window rounded style](./assets/window-rounded.webp) |
+| `slanted` | Each window is separated with slanted separators.                        | ![window slanted style](./assets/window-slanted.webp) |
+| `custom`  | Custom separators are used. This is required to override the separators! |                                                       |
+| `none`    | Styling of the window status is completely disabled.                     | ![window no styling](./assets/window-none.webp)       |
 
 If you want to change the active color to something else (the default is peach), use the following. For example to use lavender:
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,6 +7,6 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/default_options.sh --expected "${script_dir}"/tests/default_options_expected.txt "$@"
 
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/application_module.sh --expected "${script_dir}"/tests/application_module_expected.txt "$@"
-"${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/battery_module.sh --expected /dev/null "$@"
+"${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/battery_module.sh --expected "${script_dir}"/tests/battery_module_expected.txt "$@"
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/cpu_module.sh --expected "${script_dir}"/tests/cpu_module_expected.txt "$@"
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/pane_styling.sh --expected "${script_dir}"/tests/pane_styling_expected.txt "$@"

--- a/status/battery.conf
+++ b/status/battery.conf
@@ -15,7 +15,7 @@ set -ogq @batt_icon_status_discharging "󰂃"
 set -ogq @batt_icon_status_unknown "󰂑"
 set -ogq @batt_icon_status_attached "󱈑"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{battery_icon} "
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{l:#{battery_icon}} "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{l:#{battery_percentage}}"
 

--- a/status/battery.conf
+++ b/status/battery.conf
@@ -15,8 +15,8 @@ set -ogq @batt_icon_status_discharging "󰂃"
 set -ogq @batt_icon_status_unknown "󰂑"
 set -ogq @batt_icon_status_attached "󱈑"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{battery_icon} "
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{l:#{battery_icon}} "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
-set -ogq "@catppuccin_${MODULE_NAME}_text" "#{battery_percentage}"
+set -ogq "@catppuccin_${MODULE_NAME}_text" "#{l:#{battery_percentage}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/battery.conf
+++ b/status/battery.conf
@@ -15,8 +15,8 @@ set -ogq @batt_icon_status_discharging "󰂃"
 set -ogq @batt_icon_status_unknown "󰂑"
 set -ogq @batt_icon_status_attached "󱈑"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{l:#{battery_icon}} "
+set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{battery_icon} "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
-set -ogq "@catppuccin_${MODULE_NAME}_text" "#{l:#{battery_percentage}}"
+set -ogq "@catppuccin_${MODULE_NAME}_text" "#{battery_percentage}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/tests/battery_module.sh
+++ b/tests/battery_module.sh
@@ -8,10 +8,4 @@ source "${script_dir}/helpers.sh"
 tmux source "${script_dir}/../catppuccin_options_tmux.conf"
 tmux source "${script_dir}/../catppuccin_tmux.conf"
 
-print_option @catppuccin_battery_icon | grep -q "#{battery_icon}" ||
-  echo "@catppuccin_status_battery expanded #{battery_icon} in @catppuccin_battery_icon"
-
-NL='
-'
-[[ "$(print_option @catppuccin_battery_icon)" == "${NL}@catppuccin_battery_icon #{l:#{battery_icon}} " ]] ||
-  echo "@catppuccin_status_battery expanded #{battery_icon} as literal in @catppuccin_battery_icon"
+print_option @catppuccin_status_battery

--- a/tests/battery_module.sh
+++ b/tests/battery_module.sh
@@ -10,3 +10,6 @@ tmux source "${script_dir}/../catppuccin_tmux.conf"
 
 print_option @catppuccin_battery_icon | grep -q "#{battery_icon}" ||
   echo "@catppuccin_status_battery expanded #{battery_icon} in @catppuccin_battery_icon"
+
+print_option @catppuccin_battery_icon | grep -q "#{l:#{battery_icon}}" ||
+  echo "@catppuccin_status_battery expanded #{battery_icon} as literal in @catppuccin_battery_icon"

--- a/tests/battery_module.sh
+++ b/tests/battery_module.sh
@@ -11,5 +11,7 @@ tmux source "${script_dir}/../catppuccin_tmux.conf"
 print_option @catppuccin_battery_icon | grep -q "#{battery_icon}" ||
   echo "@catppuccin_status_battery expanded #{battery_icon} in @catppuccin_battery_icon"
 
-print_option @catppuccin_battery_icon | grep -q "#{l:#{battery_icon}}" ||
+NL='
+'
+[[ "$(print_option @catppuccin_battery_icon)" == "${NL}@catppuccin_battery_icon #{l:#{battery_icon}} " ]] ||
   echo "@catppuccin_status_battery expanded #{battery_icon} as literal in @catppuccin_battery_icon"

--- a/tests/battery_module_expected.txt
+++ b/tests/battery_module_expected.txt
@@ -1,0 +1,1 @@
+@catppuccin_status_battery #[fg=#f9e2af,nobold,nounderscore,noitalics]#[fg=#11111b,bg=#f9e2af]#{l:#{battery_icon}} #[fg=#f9e2af,bg=#45475a]#[fg=#cdd6f4] #{E:@catppuccin_battery_text}#[fg=#45475a]█


### PR DESCRIPTION
Need the `battery_icon` format to expand as a literal for the battery plugin to find it and replace it.