### PR TITLE
style(status): use @catppuccin_status_background as background color

### DIFF
--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -52,4 +52,4 @@ set -ogq @catppuccin_status_middle_separator ""
 set -ogq @catppuccin_status_right_separator "█"
 set -ogq @catppuccin_status_connect_separator "yes" # yes, no
 set -ogq @catppuccin_status_fill "icon"
-set -ogq @catppuccin_status_default_background "#{E:@thm_surface_1}"
+set -ogq @catppuccin_status_default_background "#{@thm_surface_1}"

--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -52,3 +52,4 @@ set -ogq @catppuccin_status_middle_separator ""
 set -ogq @catppuccin_status_right_separator "█"
 set -ogq @catppuccin_status_connect_separator "yes" # yes, no
 set -ogq @catppuccin_status_fill "icon"
+set -ogq @catppuccin_status_default_background "#{@thm_surface_1}"

--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -52,4 +52,3 @@ set -ogq @catppuccin_status_middle_separator ""
 set -ogq @catppuccin_status_right_separator "█"
 set -ogq @catppuccin_status_connect_separator "yes" # yes, no
 set -ogq @catppuccin_status_fill "icon"
-set -ogq @catppuccin_status_default_background "#{@thm_surface_1}"

--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -52,4 +52,4 @@ set -ogq @catppuccin_status_middle_separator ""
 set -ogq @catppuccin_status_right_separator "█"
 set -ogq @catppuccin_status_connect_separator "yes" # yes, no
 set -ogq @catppuccin_status_fill "icon"
-set -ogq @catppuccin_status_default_background "#{@thm_surface_1}"
+set -ogq @catppuccin_status_default_background "#{E:@thm_surface_1}"

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -1,5 +1,23 @@
 source -F "#{d:current_file}/themes/catppuccin_#{@catppuccin_flavor}_tmux.conf"
 
+%if "#{==:#{@catppuccin_status_background},default}"
+  set -gF @_ctp_status_bg "#{@thm_surface_1}"
+  set -gF status-style "bg=#{@_ctp_status_bg},fg=#{@thm_fg}"
+
+  %hidden CTP_MESSAGE_BACKGROUND="#{@thm_surface_0}"
+%elif "#{==:#{@catppuccin_status_background},none}"
+  set -g status-style "default"
+  set -g @_ctp_status_bg "none"
+
+  %hidden CTP_MESSAGE_BACKGROUND="default"
+%else
+  # Treat @catppuccin_status_background as a format string.
+  set -gF status-style "bg=#{E:@catppuccin_status_background},fg=#{@thm_fg}"
+  set -gF @_ctp_status_bg "#{E:@catppuccin_status_background}"
+
+  %hidden CTP_MESSAGE_BACKGROUND="#{E:@catppuccin_status_background}"
+%endif
+
 source -F "#{d:current_file}/status/application.conf"
 source -F "#{d:current_file}/status/battery.conf"
 source -F "#{d:current_file}/status/clima.conf"
@@ -15,18 +33,6 @@ source -F "#{d:current_file}/status/session.conf"
 source -F "#{d:current_file}/status/uptime.conf"
 source -F "#{d:current_file}/status/user.conf"
 source -F "#{d:current_file}/status/weather.conf"
-
-%if "#{==:#{@catppuccin_status_background},default}"
-  set -gF status-style "bg=#{@thm_bg},fg=#{@thm_fg}"
-  %hidden CTP_MESSAGE_BACKGROUND="#{@thm_surface_0}"
-%elif "#{==:#{@catppuccin_status_background},none}"
-  %hidden CTP_MESSAGE_BACKGROUND="default"
-  set -g status-style "$CTP_MESSAGE_BACKGROUND"
-%else
-  # Treat @catppuccin_status_background as a format string.
-  %hidden CTP_MESSAGE_BACKGROUND="#{E:@catppuccin_status_background}"
-  set -gF status-style "bg=$CTP_MESSAGE_BACKGROUND,fg=#{@thm_fg}"
-%endif
 
 # messages
 set -gF message-style "fg=#{@thm_sky},bg=$CTP_MESSAGE_BACKGROUND,align=centre"

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -16,7 +16,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 # If _only_ the icon should be filled in, then change the background
 # to catppuccin_status_default_background, and the foreground to crust. Otherwise leave the formatting as-is.
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=#{E:@catppuccin_status_default_background}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
+  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=#{E:@_ctp_status_bg}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "]#{@catppuccin_status_middle_separator}#[fg=#{@thm_crust}]"
 %endif
@@ -24,7 +24,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 set -ag "@catppuccin_status_${MODULE_NAME}" "#{E:@catppuccin_${MODULE_NAME}_text}"
 
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{E:@catppuccin_status_default_background}]"
+  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{E:@_ctp_status_bg}]"
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_color}]"
 %endif

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -16,7 +16,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 # If _only_ the icon should be filled in, then change the background
 # to catppuccin_status_default_background, and the foreground to crust. Otherwise leave the formatting as-is.
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=#{@catppuccin_status_default_background}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
+  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=#{E:@catppuccin_status_default_background}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "]#{@catppuccin_status_middle_separator}#[fg=#{@thm_crust}]"
 %endif
@@ -24,7 +24,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 set -ag "@catppuccin_status_${MODULE_NAME}" "#{E:@catppuccin_${MODULE_NAME}_text}"
 
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_status_default_background}]"
+  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{E:@catppuccin_status_default_background}]"
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_color}]"
 %endif

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -3,7 +3,7 @@
 # Embedded style that ensures that modules look "connected"
 # when required.
 set -gqF @_ctp_connect_style \
-  "#{?#{==:#{@catppuccin_status_connect_separator},yes},,#[bg=default]}"
+  "#{?#{==:#{@catppuccin_status_connect_separator},yes},,#[bg=${CTP_MESSAGE_BACKGROUND}]}"
 
 set -gF "@catppuccin_status_${MODULE_NAME}" \
   "#[fg=#{@catppuccin_${MODULE_NAME}_color},nobold,nounderscore,noitalics]#{@_ctp_connect_style}#{@catppuccin_status_left_separator}"
@@ -16,7 +16,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 # If _only_ the icon should be filled in, then change the background
 # to surface_1, and the foreground to crust. Otherwise leave the formatting as-is.
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=#{@thm_surface_1}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
+  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=${CTP_MESSAGE_BACKGROUND}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "]#{@catppuccin_status_middle_separator}#[fg=#{@thm_crust}]"
 %endif
@@ -24,7 +24,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 set -ag "@catppuccin_status_${MODULE_NAME}" "#{E:@catppuccin_${MODULE_NAME}_text}"
 
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@thm_surface_1}]"
+  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=${CTP_MESSAGE_BACKGROUND}]"
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_color}]"
 %endif

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -3,7 +3,7 @@
 # Embedded style that ensures that modules look "connected"
 # when required.
 set -gqF @_ctp_connect_style \
-  "#{?#{==:#{@catppuccin_status_connect_separator},yes},,#[bg=${CTP_MESSAGE_BACKGROUND}]}"
+  "#{?#{==:#{@catppuccin_status_connect_separator},yes},,#[bg=default]}"
 
 set -gF "@catppuccin_status_${MODULE_NAME}" \
   "#[fg=#{@catppuccin_${MODULE_NAME}_color},nobold,nounderscore,noitalics]#{@_ctp_connect_style}#{@catppuccin_status_left_separator}"
@@ -14,9 +14,9 @@ set -agF "@catppuccin_status_${MODULE_NAME}" \
 set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_color},"
 
 # If _only_ the icon should be filled in, then change the background
-# to surface_1, and the foreground to crust. Otherwise leave the formatting as-is.
+# to catppuccin_status_default_background, and the foreground to crust. Otherwise leave the formatting as-is.
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=${CTP_MESSAGE_BACKGROUND}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
+  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=#{@catppuccin_status_default_background}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "]#{@catppuccin_status_middle_separator}#[fg=#{@thm_crust}]"
 %endif
@@ -24,7 +24,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 set -ag "@catppuccin_status_${MODULE_NAME}" "#{E:@catppuccin_${MODULE_NAME}_text}"
 
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=${CTP_MESSAGE_BACKGROUND}]"
+  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_status_default_background}]"
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_color}]"
 %endif


### PR DESCRIPTION
When changing the background of the status bar, I think the default background color of all modules should be this color. 
 
Therefore, the hard coded references to `default` and `thm_surface_1` in `utils/status_module.conf` should be in my opinion changed to `${CTP_MESSAGE_BACKGROUND}`. With this changes the background color of the status bar is always the same. 
 
I'm not so familiar with the new tmux configuration style. I hope that this is the correct way to solve the problem. 