### PR TITLE
fix(window): middle separator colors

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -184,17 +184,18 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
 
   %else
 
-    # The left and middle separators are the same between "all" and "number".
+    # The left separator is the same between "all" and "number".
     # The number is the same as well.
     set -g @_ctp_w_left \
       "#[fg=#{E:@catppuccin_window_default_background},bg=default]#{@catppuccin_window_left_separator}"
-    set -g @_ctp_w_middle \
-      "#[fg=#{E:@catppuccin_window_default_background},bg=#{E:@catppuccin_window_default_color}]#{@catppuccin_window_middle_separator}"
     set -g @_ctp_w_number \
       "#[fg=#{@thm_crust},bg=#{E:@catppuccin_window_default_background}]##I"
 
     %if "#{==:#{@catppuccin_window_default_fill},all}"
 
+      # Inherit colors from text or number
+      set -g @_ctp_w_middle \
+        "#{@catppuccin_window_current_middle_separator}"
       set -g @_ctp_w_right \
         "#[fg=#{E:@catppuccin_window_default_background},bg=default]#{@catppuccin_window_right_separator}"
       set -g @_ctp_w_text \
@@ -202,6 +203,8 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
 
     %elif "#{==:#{@catppuccin_window_default_fill},number}"
 
+      set -g @_ctp_w_middle \
+        "#[fg=#{E:@catppuccin_window_default_background},bg=#{E:@catppuccin_window_default_color}]#{@catppuccin_window_middle_separator}"
       set -g @_ctp_w_text \
           "#[fg=#{@thm_fg},bg=#{E:@catppuccin_window_default_color}]#{@catppuccin_window_default_text}"
 
@@ -250,17 +253,18 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
 
   %else
 
-    # The left and middle separators are the same between "all" and "number".
+    # The left separator is the same between "all" and "number".
     # The number is the same as well.
     set -g @_ctp_w_left \
       "#[fg=#{E:@catppuccin_window_current_background},bg=default]#{@catppuccin_window_current_left_separator}"
-    set -g @_ctp_w_middle \
-      "#[fg=#{E:@catppuccin_window_current_background},bg=#{E:@catppuccin_window_current_color}]#{@catppuccin_window_current_middle_separator}"
     set -g @_ctp_w_number \
       "#[fg=#{@thm_crust},bg=#{E:@catppuccin_window_current_background}]##I"
 
     %if "#{==:#{@catppuccin_window_current_fill},all}"
 
+      # Inherit colors from text or number
+      set -g @_ctp_w_middle \
+        "#{@catppuccin_window_current_middle_separator}"
       set -g @_ctp_w_right \
         "#[fg=#{E:@catppuccin_window_current_background},bg=default]#{@catppuccin_window_current_right_separator}"
       set -g @_ctp_w_text \
@@ -268,6 +272,8 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
 
     %elif "#{==:#{@catppuccin_window_current_fill},number}"
 
+      set -g @_ctp_w_middle \
+        "#[fg=#{E:@catppuccin_window_current_background},bg=#{E:@catppuccin_window_current_color}]#{@catppuccin_window_current_middle_separator}"
       set -g @_ctp_w_text \
         "#[fg=#{@thm_fg},bg=#{E:@catppuccin_window_current_color}]#{@catppuccin_window_current_text}"
 

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -184,15 +184,14 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
 
   %else
 
-    # The left separator is the same between "all" and "number".
-    # The number is the same as well.
-    set -g @_ctp_w_left \
-      "#[fg=#{E:@catppuccin_window_default_background},bg=default]#{@catppuccin_window_left_separator}"
+    # The number is the same between "all" and "number".
     set -g @_ctp_w_number \
       "#[fg=#{@thm_crust},bg=#{E:@catppuccin_window_default_background}]##I"
 
     %if "#{==:#{@catppuccin_window_default_fill},all}"
 
+      set -g @_ctp_w_left \
+        "#[fg=#{E:@catppuccin_window_default_background},bg=default]#{@catppuccin_window_left_separator}"
       # Inherit colors from text or number
       set -g @_ctp_w_middle \
         "#{@catppuccin_window_current_middle_separator}"
@@ -253,15 +252,14 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
 
   %else
 
-    # The left separator is the same between "all" and "number".
-    # The number is the same as well.
-    set -g @_ctp_w_left \
-      "#[fg=#{E:@catppuccin_window_current_background},bg=default]#{@catppuccin_window_current_left_separator}"
+    # The number is the same between "all" and "number".
     set -g @_ctp_w_number \
       "#[fg=#{@thm_crust},bg=#{E:@catppuccin_window_current_background}]##I"
 
     %if "#{==:#{@catppuccin_window_current_fill},all}"
 
+      set -g @_ctp_w_left \
+        "#[fg=#{E:@catppuccin_window_current_background},bg=default]#{@catppuccin_window_current_left_separator}"
       # Inherit colors from text or number
       set -g @_ctp_w_middle \
         "#{@catppuccin_window_current_middle_separator}"


### PR DESCRIPTION
`middle_separator` is _not_ the same for fill `number` and `all`, for fill the colors are the same as text or color (or the reverse of middle sep with number fill).

before:
![image](https://github.com/user-attachments/assets/08045305-c700-4220-8774-a07502941fc6)
after:
![image](https://github.com/user-attachments/assets/fedd2d3f-b07a-4e99-925a-107c310b4dcd)


Also changed where `@_ctp_w_left` is set since it was _always_ overwritten when the fill is number.

<details>
<summary>config</summary>

```tmux
# Window
set -g @catppuccin_window_status_style "custom"
set -g window-status-separator ""

## Window global/default configuration
set -g @catppuccin_window_default_text "#{pane_title}"
set -g @catppuccin_window_status "icon"
set -g @catppuccin_window_default_fill "number"
set -g @catppuccin_window_number_position "left"

set -g @catppuccin_window_left_separator "█"
set -g @catppuccin_window_middle_separator "█ "
set -g @catppuccin_window_right_separator ""

## Window current configuration
set -g @catppuccin_window_current_text "#{pane_title}"
set -g @catppuccin_window_current_fill "all"
set -g @catppuccin_window_current_middle_separator " 󰿟 "
```
</details>

Fixes #353