### PR TITLE
fix(ci): update tmux in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux=3.2a-4ubuntu0.2
+        run: sudo apt-get update && sudo apt-get install -y tmux=3.4-1build1
       - uses: actions/checkout@v4
       - name: Run Tests
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux=3.4-1build1
+        run: sudo apt update && sudo apt install -y --allow-downgrades tmux=3.4-1build1
       - uses: actions/checkout@v4
       - name: Run Tests
         shell: bash


### PR DESCRIPTION
`ubuntu-latest` is `ubuntu-24.04`, see https://github.com/actions/runner-images?tab=readme-ov-file#available-images.

`ubuntu24.04` has [tmux version `3.4-1build1`](https://packages.ubuntu.com/noble/tmux).

Don't know what the best option is 
 - "upgrading" the tmux version
 - another image, for example `ubuntu-22.04`
 - matrix of `ubuntu-20.04`, `ubuntu-22.04`, `ubuntu-24.04`/`ubuntu-latest`
 - building tmux from source, don't think this is a good idea just adding it to complete the list