### PR TITLE
fix(weather status): Use tmux-weather's cache var

### DIFF
--- a/status/weather.conf
+++ b/status/weather.conf
@@ -5,6 +5,6 @@
 
 set -ogq @catppuccin_weather_icon " "
 set -ogqF @catppuccin_weather_color "#{@thm_yellow}"
-set -ogq @catppuccin_weather_text "#{l:#{weather}}"
+set -ogq @catppuccin_weather_text "#{@weather-previous-value}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"


### PR DESCRIPTION
After upgrading I found my weather status was not working.

xamut/tmux-weather looks for '#{weather}' in status-right to replace with the downloaded weather data.

However it can't find it as status-right will only contain '#{E:@catppuccin_status_weather}', and results in only the text '#{weather}' being displayed.

So instead of using the literal '#{weather}' in the status module, use the var that xamut/tmux-wether uses to cache it's results.

Tested on my own systems.