### PR TITLE
fix: replace @_ctp_status_bg with @thm_surface_0 in module configurtion to properly show module separation

### DIFF
--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -52,3 +52,4 @@ set -ogq @catppuccin_status_middle_separator ""
 set -ogq @catppuccin_status_right_separator "█"
 set -ogq @catppuccin_status_connect_separator "yes" # yes, no
 set -ogq @catppuccin_status_fill "icon"
+set -ogq @catppuccin_status_module_bg_color "#{@thm_surface_0}"

--- a/status/README.md
+++ b/status/README.md
@@ -14,6 +14,14 @@ set -g @catppuccin_[module_name]_icon "icon"
 set -g @catppuccin_[module_name]_color "color"
 ```
 
+#### Override the specific module background color
+
+##### (NB: Only when `@catppuccin_status_fill` is `icon`)
+
+```sh
+set -g @catppuccin_status_[module_name]_bg_color "color"
+```
+
 #### Override the specific module text
 
 ```sh

--- a/tests/application_module_expected.txt
+++ b/tests/application_module_expected.txt
@@ -1,1 +1,1 @@
-@catppuccin_status_application #[fg=#f5c2e7,nobold,nounderscore,noitalics]#[fg=#11111b,bg=#f5c2e7] #[fg=#f5c2e7,bg=#181825]#[fg=#cdd6f4] #{E:@catppuccin_application_text}#[fg=#181825]█
+@catppuccin_status_application #[fg=#f5c2e7,nobold,nounderscore,noitalics]#[fg=#11111b,bg=#f5c2e7] #[fg=#f5c2e7,bg=#313244]#[fg=#cdd6f4] #{E:@catppuccin_application_text}#[fg=#313244]█

--- a/tests/battery_module_expected.txt
+++ b/tests/battery_module_expected.txt
@@ -1,1 +1,1 @@
-@catppuccin_status_battery #[fg=#f9e2af,nobold,nounderscore,noitalics]#[fg=#11111b,bg=#f9e2af]#{l:#{battery_icon}} #[fg=#f9e2af,bg=#181825]#[fg=#cdd6f4] #{E:@catppuccin_battery_text}#[fg=#181825]█
+@catppuccin_status_battery #[fg=#f9e2af,nobold,nounderscore,noitalics]#[fg=#11111b,bg=#f9e2af]#{l:#{battery_icon}} #[fg=#f9e2af,bg=#313244]#[fg=#cdd6f4] #{E:@catppuccin_battery_text}#[fg=#313244]█

--- a/tests/cpu_module_expected.txt
+++ b/tests/cpu_module_expected.txt
@@ -1,1 +1,1 @@
-E:@catppuccin_status_cpu #[fg=#{cpu_bg_color},nobold,nounderscore,noitalics]#[fg=#11111b,bg=#{cpu_bg_color}] #[fg=#{cpu_bg_color},bg=#181825]#[fg=#cdd6f4] #{cpu_percentage}#[fg=#181825]█
+E:@catppuccin_status_cpu #[fg=#{cpu_bg_color},nobold,nounderscore,noitalics]#[fg=#11111b,bg=#{cpu_bg_color}] #[fg=#{cpu_bg_color},bg=#313244]#[fg=#cdd6f4] #{cpu_percentage}#[fg=#313244]█

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -5,6 +5,12 @@
 set -gqF @_ctp_connect_style \
   "#{?#{==:#{@catppuccin_status_connect_separator},yes},,#[bg=default]}"
 
+%if "#{==:#{@catppuccin_status_${MODULE_NAME}_bg_color},}"
+  set -gqF @_ctp_module_bg_color "#{@catppuccin_status_module_bg_color}"
+%else
+  set -gqF @_ctp_module_bg_color "#{@catppuccin_status_${MODULE_NAME}_bg_color}"
+%endif
+
 set -gF "@catppuccin_status_${MODULE_NAME}" \
   "#[fg=#{@catppuccin_${MODULE_NAME}_color},nobold,nounderscore,noitalics]#{@_ctp_connect_style}#{@catppuccin_status_left_separator}"
 
@@ -16,7 +22,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 # If _only_ the icon should be filled in, then change the background
 # to catppuccin_status_default_background, and the foreground to crust. Otherwise leave the formatting as-is.
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=#{E:@_ctp_status_bg}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
+  set -agF "@catppuccin_status_${MODULE_NAME}" "bg=#{@_ctp_module_bg_color}]#{@catppuccin_status_middle_separator}#[fg=#{@thm_fg}] "
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "]#{@catppuccin_status_middle_separator}#[fg=#{@thm_crust}]"
 %endif
@@ -24,7 +30,7 @@ set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_
 set -ag "@catppuccin_status_${MODULE_NAME}" "#{E:@catppuccin_${MODULE_NAME}_text}"
 
 %if "#{==:#{@catppuccin_status_fill},icon}"
-  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{E:@_ctp_status_bg}]"
+  set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@_ctp_module_bg_color}]"
 %else
   set -agF "@catppuccin_status_${MODULE_NAME}" "#[fg=#{@catppuccin_${MODULE_NAME}_color}]"
 %endif

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -6,9 +6,9 @@ set -gqF @_ctp_connect_style \
   "#{?#{==:#{@catppuccin_status_connect_separator},yes},,#[bg=default]}"
 
 %if "#{==:#{@catppuccin_status_${MODULE_NAME}_bg_color},}"
-  set -gqF @_ctp_module_bg_color "#{@catppuccin_status_module_bg_color}"
+  set -gqF @_ctp_module_bg_color "#{E:@catppuccin_status_module_bg_color}"
 %else
-  set -gqF @_ctp_module_bg_color "#{@catppuccin_status_${MODULE_NAME}_bg_color}"
+  set -gqF @_ctp_module_bg_color "#{E:@catppuccin_status_${MODULE_NAME}_bg_color}"
 %endif
 
 set -gF "@catppuccin_status_${MODULE_NAME}" \


### PR DESCRIPTION
**Before the change:**
With `@catppuccin_status_connect_separator` set to `yes` or `no`
<img width="2202" alt="Screenshot 2024-10-17 at 12 04 22 pm" src="https://github.com/user-attachments/assets/6b916935-314a-4c75-91b8-54be33954f2d">

**After the change:**
With `@catppuccin_status_connect_separator` set to `yes`
<img width="2190" alt="Screenshot 2024-10-17 at 12 09 50 pm" src="https://github.com/user-attachments/assets/d746cd36-7a17-4331-a9c1-575170c4263c">

With `@catppuccin_status_connect_separator` set to `no`
<img width="2197" alt="Screenshot 2024-10-17 at 12 08 59 pm" src="https://github.com/user-attachments/assets/e306cc73-573a-4136-a773-0283008dbc7a">

