### PR TITLE
Fix up the docs to make configuration match screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,10 +420,12 @@ set -g @catppuccin_window_status_style "rounded"
 set -g @catppuccin_window_number_position "right"
 
 set -g @catppuccin_window_default_fill "number"
-set -g @catppuccin_window_default_text "#W"
+set -g @catppuccin_window_default_text "#W "
+set -g @catppuccin_window_default_background "#{@thm_blue}"
 
 set -g @catppuccin_window_current_fill "number"
-set -g @catppuccin_window_current_text "#W"
+set -g @catppuccin_window_current_text "#W "
+set -g @catppuccin_window_current_background "#{@thm_peach}"
 
 set -g @catppuccin_status_left_separator  " "
 set -g @catppuccin_status_right_separator ""


### PR DESCRIPTION
The screenshot has blue background for numbers on non-current windows, and space between text and number on right. Update sample config to make sure it matches result in screenshot. Without `@thm_blue` it will default to grey.