### PR TITLE
Issue #389: Need dynamic middle separator when slanted

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -143,7 +143,11 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
 %elif "#{==:#{@catppuccin_window_status_style},slanted}"
 
   set -gq @catppuccin_window_left_separator "█"
-  set -gq @catppuccin_window_middle_separator "█"
+  %if "#{==:#{@catppuccin_window_number_position},left}"
+    set -gq @catppuccin_window_middle_separator "█"
+  %else
+    set -gq @catppuccin_window_middle_separator "█"
+  %endif
   set -gq @catppuccin_window_right_separator "█ "
 
 %endif


### PR DESCRIPTION
Saw this may be fixed in a v2.0.0, but I think this'll fix just issue #389, if you want it.