### PR TITLE
Fix cpu status in wrong format

### DIFF
--- a/status/cpu.conf
+++ b/status/cpu.conf
@@ -1,6 +1,10 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="cpu"
 
+set -ogqF @cpu_low_bg_color "#{@thm_green}"
+set -ogqF @cpu_medium_bg_color "#{@thm_yellow}"
+set -ogqF @cpu_high_bg_color "#{@thm_red}"
+
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
 set -ogq "@catppuccin_${MODULE_NAME}_color" "#{l:#{cpu_bg_color}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{l:#{cpu_percentage}}"


### PR DESCRIPTION
cpu_bg_color is replaced by "#[bg=green]" by the plugin. But the expecting value from catppuccin is just "green" that is just color value.