### PR TITLE
Fix session status icon bg color change by client_prefix

### DIFF
--- a/status/session.conf
+++ b/status/session.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="session"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "##{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
+set -ogq "@catppuccin_${MODULE_NAME}_color" "##{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #S"
 
 source -F "#{d:current_file}/../utils/status_module.conf"


### PR DESCRIPTION
The bg color of icon is always green.
I think the expands should be done later. There might be more cases.
This bug is observed on v2 but not v1.0.3.