### PR TITLE
build: allow release-please to release on more scopes

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -15,7 +15,6 @@
   },
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
-    { "type": "feature", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
     { "type": "perf", "section": "Performance Improvements" },
     { "type": "revert", "section": "Reverts" },

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -13,5 +13,13 @@
       ]
     }
   },
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "feature", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation" }
+  ]
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
This PR adjusts the changelog sections so that `perf`, `revert` and `docs` commits are tracked in the CHANGELOG and are suitable candidates for the creation of a release please PR.

In an ideal world, the commits included in the CHANGELOG and the scopes responsible for the creation of the release please PR would be decoupled but it seems as though that is not currently possible. 