### PR TITLE
fix: Issue #407 and dynamic colors in status modules

### DIFF
--- a/status/battery.conf
+++ b/status/battery.conf
@@ -16,7 +16,7 @@ set -ogq @batt_icon_status_unknown "󰂑"
 set -ogq @batt_icon_status_attached "󱈑"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{l:#{battery_icon}} "
-set -ogq "@catppuccin_${MODULE_NAME}_color" "#{@thm_lavender}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_lavender}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{l:#{battery_percentage}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/cpu.conf
+++ b/status/cpu.conf
@@ -1,12 +1,18 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="cpu"
 
-set -ogq @cpu_low_bg_color "#[bg=none]"
-set -ogq @cpu_medium_bg_color "#[bg=none]"
-set -ogq @cpu_high_bg_color "#[bg=#{@thm_red},fg=#{@thm_crust}]"
+set -ogq @cpu_low_fg_color "#{E:@thm_fg}"
+set -ogq @cpu_medium_fg_color "#{E:@thm_fg}"
+set -ogq @cpu_high_fg_color "#{E:@thm_crust}"
+
+set -ogq @cpu_low_bg_color "#{E:@catppuccin_status_module_text_bg}"
+set -ogq @cpu_medium_bg_color "#{E:@catppuccin_status_module_text_bg}"
+set -ogq @cpu_high_bg_color "#{E:@thm_red}"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogq "@catppuccin_${MODULE_NAME}_color" "#{@thm_yellow}"
-set -ogq "@catppuccin_${MODULE_NAME}_text" " #{l:#{cpu_bg_color}#{cpu_percentage}}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
+set -ogq "@catppuccin_status_${MODULE_NAME}_text_fg" "#{l:#{cpu_fg_color}}"
+set -ogq "@catppuccin_status_${MODULE_NAME}_text_bg" "#{l:#{cpu_bg_color}}"
+set -ogq "@catppuccin_${MODULE_NAME}_text" " #{l:#{cpu_percentage}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/gitmux.conf
+++ b/status/gitmux.conf
@@ -3,7 +3,7 @@
 
 # Requires https://github.com/arl/gitmux
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊢 "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_teal}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_teal}"
 set -gq "@catppuccin_${MODULE_NAME}_text" ' #(gitmux -cfg $HOME/.gitmux.conf "#{pane_current_path}")'
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/kube.conf
+++ b/status/kube.conf
@@ -4,9 +4,9 @@
 # Requires https://github.com/jonmosco/kube-tmux
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󱃾 "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_blue}"
-set -ogqF "@catppuccin_kube_context_color" "#{@thm_red}"
-set -ogqF "@catppuccin_kube_namespace_color" "#{@thm_sky}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
+set -ogqF "@catppuccin_kube_context_color" "#{E:@thm_red}"
+set -ogqF "@catppuccin_kube_namespace_color" "#{E:@thm_sky}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" \
    " #(${TMUX_PLUGIN_MANAGER_PATH}kube-tmux/kube.tmux 250 #{@catppuccin_kube_context_color} #{@catppuccin_kube_namespace_color})"
 

--- a/status/load.conf
+++ b/status/load.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="load"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊚 "
-set -ogq "@catppuccin_${MODULE_NAME}_color" "#{@thm_blue}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{load_full}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/session.conf
+++ b/status/session.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="session"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogq "@catppuccin_${MODULE_NAME}_color" "##{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "##{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #S"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/session.conf
+++ b/status/session.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="session"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "##{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
+set -ogq "@catppuccin_${MODULE_NAME}_color" "##{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #S"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/session.conf
+++ b/status/session.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="session"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogq "@catppuccin_${MODULE_NAME}_color" "##{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
+set -ogq "@catppuccin_${MODULE_NAME}_color" "#{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #S"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/uptime.conf
+++ b/status/uptime.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="uptime"
 
 set -ogq @catppuccin_uptime_icon "󰔟 "
-set -ogqF @catppuccin_uptime_color "#{@thm_sapphire}"
+set -ogqF @catppuccin_uptime_color "#{E:@thm_sapphire}"
 set -ogq @catppuccin_uptime_text " #(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/user.conf
+++ b/status/user.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="user"
 
 set -ogq @catppuccin_user_icon " "
-set -ogqF @catppuccin_user_color "#{@thm_sky}"
+set -ogqF @catppuccin_user_color "#{E:@thm_sky}"
 set -ogq @catppuccin_user_text " #(whoami)"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/weather.conf
+++ b/status/weather.conf
@@ -4,7 +4,7 @@
 # Requires https://github.com/xamut/tmux-weather.
 
 set -ogq @catppuccin_weather_icon " "
-set -ogqF @catppuccin_weather_color "#{@thm_yellow}"
+set -ogqF @catppuccin_weather_color "#{E:@thm_yellow}"
 set -ogq @catppuccin_weather_text " #{l:#{weather}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/tests/cpu_module_expected.txt
+++ b/tests/cpu_module_expected.txt
@@ -1,1 +1,1 @@
-E:@catppuccin_status_cpu #[fg=#f9e2af]#[fg=#11111b,bg=#f9e2af] #[fg=#cdd6f4,bg=#313244] #{cpu_bg_color}#{cpu_percentage}#[reverse]█#[noreverse]
+E:@catppuccin_status_cpu #[fg=#f9e2af]#[fg=#11111b,bg=#f9e2af] #[fg=#{cpu_fg_color},bg=#{cpu_bg_color}] #{cpu_percentage}#[reverse]█#[noreverse]

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -18,7 +18,7 @@ set -ogqF "@catppuccin_status_${MODULE_NAME}_icon_fg" "#{E:@thm_crust}"
 set -ogqF "@catppuccin_status_${MODULE_NAME}_text_fg" "#{E:@thm_fg}"
 
 %if "#{==:#{@catppuccin_status_${MODULE_NAME}_icon_bg},}"
-  set -gqF "@catppuccin_status_${MODULE_NAME}_icon_bg" "#{E:@catppuccin_${MODULE_NAME}_color}"
+  set -gqF "@catppuccin_status_${MODULE_NAME}_icon_bg" "#{@catppuccin_${MODULE_NAME}_color}"
 %endif
 
 %if "#{==:#{@catppuccin_status_${MODULE_NAME}_text_bg},}"

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -14,27 +14,30 @@ set -gqF @_ctp_connect_style \
 #   - fg: @catppuccin_status_[module]_text_fg [default = foreground]
 #   - bg: @catppuccin_status_[module]_text_bg [default = @catppuccin_status_module_text_bg]
 
-set -ogq "@catppuccin_status_${MODULE_NAME}_icon_fg" "#{@thm_crust}"
-set -ogq "@catppuccin_status_${MODULE_NAME}_text_fg" "#{@thm_fg}"
-set -ogqF "@catppuccin_status_${MODULE_NAME}_icon_bg" "#{@catppuccin_${MODULE_NAME}_color}"
+set -ogqF "@catppuccin_status_${MODULE_NAME}_icon_fg" "#{E:@thm_crust}"
+set -ogqF "@catppuccin_status_${MODULE_NAME}_text_fg" "#{E:@thm_fg}"
+
+%if "#{==:#{@catppuccin_status_${MODULE_NAME}_icon_bg},}"
+  set -gqF "@catppuccin_status_${MODULE_NAME}_icon_bg" "#{E:@catppuccin_${MODULE_NAME}_color}"
+%endif
 
 %if "#{==:#{@catppuccin_status_${MODULE_NAME}_text_bg},}"
   set -gqF @_ctp_module_text_bg "#{E:@catppuccin_status_module_text_bg}"
 %else
-  set -gqF @_ctp_module_text_bg "#{E:@catppuccin_status_${MODULE_NAME}_text_bg}"
+  set -gqF @_ctp_module_text_bg "#{@catppuccin_status_${MODULE_NAME}_text_bg}"
 %endif
 
 set -gF "@catppuccin_status_${MODULE_NAME}" \
-  "#[fg=#{E:@catppuccin_status_${MODULE_NAME}_icon_bg}]#{@_ctp_connect_style}#{@catppuccin_status_left_separator}"
+  "#[fg=#{@catppuccin_status_${MODULE_NAME}_icon_bg}]#{@_ctp_connect_style}#{@catppuccin_status_left_separator}"
 
 set -agF "@catppuccin_status_${MODULE_NAME}" \
-  "#[fg=#{E:@catppuccin_status_${MODULE_NAME}_icon_fg},bg=#{E:@catppuccin_status_${MODULE_NAME}_icon_bg}]#{@catppuccin_${MODULE_NAME}_icon}"
+  "#[fg=#{@catppuccin_status_${MODULE_NAME}_icon_fg},bg=#{@catppuccin_status_${MODULE_NAME}_icon_bg}]#{@catppuccin_${MODULE_NAME}_icon}"
 
 set -agF "@catppuccin_status_${MODULE_NAME}" \
   "#{@catppuccin_status_middle_separator}"
 
 set -agF "@catppuccin_status_${MODULE_NAME}" \
-  "#[fg=#{E:@catppuccin_status_${MODULE_NAME}_text_fg},bg=#{@_ctp_module_text_bg}]"
+  "#[fg=#{@catppuccin_status_${MODULE_NAME}_text_fg},bg=#{@_ctp_module_text_bg}]"
 
 set -ag "@catppuccin_status_${MODULE_NAME}" "#{E:@catppuccin_${MODULE_NAME}_text}"
 


### PR DESCRIPTION
This PR fixes the issue #407 and enables dynamic color for text and icon in status modules.

E.g. the following custom module:

``` sh
%hidden MODULE_NAME='memory'

# see https://github.com/tmux-plugins/tmux-cpu
set-option -ogq '@ram_low_bg_color' '#{E:@thm_green}'
set-option -ogq '@ram_medium_bg_color' '#{E:@thm_yellow}'
set-option -ogq '@ram_high_bg_color' '#{E:@thm_red}'

set-option -ogq "@catppuccin_${MODULE_NAME}_icon" '<U+E266> '
set-option -ogq "@catppuccin_${MODULE_NAME}_color" '#{l:#{ram_bg_color}}'
set-option -ogq "@catppuccin_${MODULE_NAME}_text" ' #{l:#{ram_percentage}}'

source-file -F '#{TMUX_PLUGIN_MANAGER_PATH}/tmux/utils/status_module.conf'
```

Results in the following status bar:

![](https://github.com/user-attachments/assets/ce27268f-8bb4-4406-8901-075cfa9b4c0c)

With the PR the expansions for the color parts in `utils/status_module.conf` are removed and the color can by changed dynamically:

![](https://github.com/user-attachments/assets/f0827503-e0d1-4fac-88b8-4ce9ea9489b6)
![](https://github.com/user-attachments/assets/e9f84fcc-3808-4d78-8a27-65ae34d7a4ad)
 
Therefore, the color handling in the existing status modules must be unified (using `set -F` and `E:`).
