### PR TITLE
feat: add option to format window number

### DIFF
--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -41,9 +41,11 @@ set -ogq @catppuccin_window_status_style "basic" # basic, rounded, slanted, cust
 set -ogq @catppuccin_window_text_color "#{@thm_surface_0}"
 set -ogq @catppuccin_window_number_color "#{@thm_overlay_2}"
 set -ogq @catppuccin_window_text " #T"
+set -ogq @catppuccin_window_number "#I"
 set -ogq @catppuccin_window_current_text_color "#{@thm_surface_1}"
 set -ogq @catppuccin_window_current_number_color "#{@thm_mauve}"
 set -ogq @catppuccin_window_current_text " #T"
+set -ogq @catppuccin_window_current_number "#I"
 set -ogq @catppuccin_window_number_position "left"
 
 # Window flags

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -179,7 +179,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
   set -g @_ctp_w_text_style "#[fg=#{@thm_fg},bg=#{@catppuccin_window_text_color}]"
   %if "#{==:#{@catppuccin_window_number_position},left}"
     set -gF window-status-format \
-      "#{E:@_ctp_w_number_style}#{E:@catppuccin_window_left_separator}##I"
+      "#{E:@_ctp_w_number_style}#{E:@catppuccin_window_left_separator}#{@catppuccin_window_number}"
     set -agF window-status-format "#{E:@catppuccin_window_middle_separator}"
     set -agF window-status-format \
       "#{E:@_ctp_w_text_style}#{@catppuccin_window_text}#{@_ctp_w_flags}#{E:@catppuccin_window_right_separator}"
@@ -188,7 +188,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
       "#{E:@_ctp_w_text_style}#{E:@catppuccin_window_left_separator}#{E:@_ctp_w_text_style}#{@catppuccin_window_text}#{@_ctp_w_flags}"
     set -agF window-status-format "#{E:@catppuccin_window_middle_separator}"
     set -agF window-status-format \
-      "#{E:@_ctp_w_number_style} ##I#{E:@catppuccin_window_right_separator}"
+      "#{E:@_ctp_w_number_style} #{@catppuccin_window_number}#{E:@catppuccin_window_right_separator}"
   %endif
 
   # =======================================
@@ -199,7 +199,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
   set -g @_ctp_w_text_style "#[fg=#{@thm_fg},bg=#{@catppuccin_window_current_text_color}]"
   %if "#{==:#{@catppuccin_window_number_position},left}"
     set -gF window-status-current-format \
-      "#{E:@_ctp_w_number_style}#{E:@catppuccin_window_left_separator}##I"
+      "#{E:@_ctp_w_number_style}#{E:@catppuccin_window_left_separator}#{@catppuccin_window_current_number}"
     set -agF window-status-current-format "#{E:@catppuccin_window_current_middle_separator}"
     set -agF window-status-current-format \
       "#{E:@_ctp_w_text_style}#{@catppuccin_window_current_text}#{@_ctp_w_flags}#{E:@catppuccin_window_right_separator}"
@@ -208,7 +208,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
       "#{E:@_ctp_w_text_style}#{E:@catppuccin_window_left_separator}#{E:@_ctp_w_text_style}#{@catppuccin_window_current_text}#{@_ctp_w_flags}"
     set -agF window-status-current-format "#{E:@catppuccin_window_current_middle_separator}"
     set -agF window-status-current-format \
-      "#{E:@_ctp_w_number_style} ##I#{E:@catppuccin_window_right_separator}"
+      "#{E:@_ctp_w_number_style} #{@catppuccin_window_current_number}#{E:@catppuccin_window_right_separator}"
   %endif
 
 
@@ -221,4 +221,3 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
 # Mode style. This is used for copy mode highlighting to style the current selection.
 set -gF mode-style "bg=#{@thm_surface_0},bold"
 set -gF clock-mode-colour "#{@thm_blue}"
-

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,7 +62,7 @@ set -g @catppuccin_window_right_separator ""
 
 ```sh
 # Use a value compatible with the standard tmux `menu-selected-style`
-set -g @catppuccin_menu_selected_style "fg=#{@thm_surface_0},bg=#{@thm_yellow}" 
+set -g @catppuccin_menu_selected_style "fg=#{@thm_surface_0},bg=#{@thm_yellow}"
 ```
 
 ### All options and their defaults
@@ -89,9 +89,11 @@ set -ogq @catppuccin_window_status_style "basic" # basic, rounded, slanted, cust
 set -ogq @catppuccin_window_text_color "#{@thm_surface_0}"
 set -ogq @catppuccin_window_number_color "#{@thm_overlay_2}"
 set -ogq @catppuccin_window_text " #T"
+set -ogq @catppuccin_window_number "#I"
 set -ogq @catppuccin_window_current_text_color "#{@thm_surface_1}"
 set -ogq @catppuccin_window_current_number_color "#{@thm_mauve}"
 set -ogq @catppuccin_window_current_text " #T"
+set -ogq @catppuccin_window_current_number "#I"
 set -ogq @catppuccin_window_number_position "left"
 set -ogq @catppuccin_window_flags "none"
 set -ogq @catppuccin_window_flags_icon_last " 󰖰" # -


### PR DESCRIPTION
This add the options `@catppuccin_window_number` and `@catppuccin_window_current_number` to format the window number so we can have something like:

```sh
set -g @catppuccin_window_number #[bold]Tab ###I
set -g @catppuccin_window_current_number #[bold]Tab ###I
```
