### PR TITLE
fix: improve uptime status sed script to report correct units for a few uptime scenarios

### DIFF
--- a/status/uptime.conf
+++ b/status/uptime.conf
@@ -3,6 +3,6 @@
 
 set -ogq @catppuccin_uptime_icon "󰔟 "
 set -ogqF @catppuccin_uptime_color "#{E:@thm_sapphire}"
-set -ogq @catppuccin_uptime_text " #(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/:/h /; s/ min//; s/$/m/')"
+set -ogq @catppuccin_uptime_text " #(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/ hr\\(s*\\).*/h/; s/ min\\(s*\\).*/m/; s/ sec\\(s*\\).*/s/; s/\\([0-9]\\{1,2\\}\\):\\([0-9]\\{1,2\\}\\)/\\1h \\2m/;')"
 
 source -F "#{d:current_file}/../utils/status_module.conf"


### PR DESCRIPTION
`10:31  up 36 mins, 2 users, load averages: 2.55 4.87 6.81`
<img width="105" alt="Screenshot 2024-11-20 at 2 29 15 pm" src="https://github.com/user-attachments/assets/6278cdf4-9f79-4424-9fca-a2f913980535">

`9:42  up 10 days, 25 mins, 2 users, load averages: 4.71 4.27 4.00`
<img width="152" alt="Screenshot 2024-10-21 at 9 55 39 am" src="https://github.com/user-attachments/assets/013def4b-4af9-4e8e-9978-73ecbcb05fd5">

`18:43  up 21 days, 9 hrs, 2 users, load averages: 3.99 6.48 10.99`
![Screenshot 2024-10-24 at 9 25 26 AM](https://github.com/user-attachments/assets/8fca10ff-6fc8-4fc1-a6d7-b68ee0093458)

### The following are examples of current and fixed sed scripts.

```
Uptime String: 18:43  up 9 hrs, 2 users, load averages: 3.99 6.48 10.99
Current SED: 9 hrsm
Fixed SED: 9h

Uptime String: 18:44  up  9:01, 2 users, load averages: 4.94 6.21 10.55
Current SED: 9h 01m
Fixed SED: 9h 01m

Uptime String: 9:31  up 45 secs, 2 users, load averages: 105.51 24.01 8.61
Current SED: 45 secsm
Fixed SED: 45s

Uptime String: 9:32  up 2 mins, 2 users, load averages: 109.13 55.55 22.93
Current SED: 2sm
Fixed SED: 2m

Uptime String: 22:37:29 up 4 days,  9:44,  1 user,  load average: 0.07, 0.03, 0.01
Current SED: 4d 9h 44m
Fixed SED: 4d 9h 44m

Uptime String: 11:24  up  1:54, 2 users, load averages: 5.25 11.69 13.95
Current SED: 1h 54m
Fixed SED: 1h 54m

Uptime String: 9:30  up 3 days, 0 sec, 2 users, load averages: 3.83 4.47 4.04
Current SED: 3d 0 secm
Fixed SED: 3d 0s

Uptime String: 9:42  up 3 days, 12 mins, 2 users, load averages: 4.71 4.27 4.00
Current SED: 3d 12sm
Fixed SED: 3d 12m

Uptime String: 9:56  up 10 days, 26 mins, 2 users, load averages: 2.26 2.28 2.49
Current SED: 10d 26sm
Fixed SED: 10d 26m
```
