### PR TITLE
Use current window separators for the current window format

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -202,13 +202,13 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
       "#{E:@_ctp_w_number_style}#{E:@catppuccin_window_left_separator}#{@catppuccin_window_current_number}"
     set -agF window-status-current-format "#{E:@catppuccin_window_current_middle_separator}"
     set -agF window-status-current-format \
-      "#{E:@_ctp_w_text_style}#{@catppuccin_window_current_text}#{@_ctp_w_flags}#{E:@catppuccin_window_right_separator}"
+      "#{E:@_ctp_w_text_style}#{@catppuccin_window_current_text}#{@_ctp_w_flags}#{E:@catppuccin_window_current_right_separator}"
   %else
     set -gF window-status-current-format \
       "#{E:@_ctp_w_text_style}#{E:@catppuccin_window_left_separator}#{E:@_ctp_w_text_style}#{@catppuccin_window_current_text}#{@_ctp_w_flags}"
     set -agF window-status-current-format "#{E:@catppuccin_window_current_middle_separator}"
     set -agF window-status-current-format \
-      "#{E:@_ctp_w_number_style} #{@catppuccin_window_current_number}#{E:@catppuccin_window_right_separator}"
+      "#{E:@_ctp_w_number_style} #{@catppuccin_window_current_number}#{E:@catppuccin_window_current_right_separator}"
   %endif
 
 

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -124,7 +124,7 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
 
 # popups
 %if "#{>=:#{version},3.4}"
-  set -gF popup-style "bg=#{@thm_bg},fg=#{@thm_fg}"
+  set -gF popup-style "bg=default,fg=#{@thm_fg}"
   set -gF popup-border-style "fg=#{@thm_surface_1}"
 %endif
 

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -124,7 +124,7 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
 
 # popups
 %if "#{>=:#{version},3.4}"
-  set -gF popup-style "bg=default,fg=#{@thm_fg}"
+  set -gF popup-style "bg=#{@thm_bg},fg=#{@thm_fg}"
   set -gF popup-border-style "fg=#{@thm_surface_1}"
 %endif
 


### PR DESCRIPTION
To enable the use of `@catppuccin_window_status_style "custom"`, we need to use the existing parameter @catppuccin_window_current_right_separator. This is necessary to ensure the correct separator is used in `window-status-current-format`.

Additionally, a `popup-style` change is required to maintain consistency with transparent background setups.