### PR TITLE
Inherit default style for popups

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -124,7 +124,6 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
 
 # popups
 %if "#{>=:#{version},3.4}"
-  set -gF popup-style "bg=#{@thm_bg},fg=#{@thm_fg}"
   set -gF popup-border-style "fg=#{@thm_surface_1}"
 %endif
 


### PR DESCRIPTION
The current setup can cause style inconsistencies between popups and other windows/elements, particularly when using transparent backgrounds.

This change will resolve that issue (popups will inherit default colors for foreground and background).

Since this plugin doesn't utilize `window-active-style` or `menu-style`, there's no need for `popup-style` either.