### PR TITLE
Fix: use the correct option for the left separator for the current window

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -199,13 +199,13 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
   set -g @_ctp_w_text_style "#[fg=#{@thm_fg},bg=#{@catppuccin_window_current_text_color}]"
   %if "#{==:#{@catppuccin_window_number_position},left}"
     set -gF window-status-current-format \
-      "#{E:@_ctp_w_number_style}#{E:@catppuccin_window_left_separator}#{@catppuccin_window_current_number}"
+      "#{E:@_ctp_w_number_style}#{E:@catppuccin_window_current_left_separator}#{@catppuccin_window_current_number}"
     set -agF window-status-current-format "#{E:@catppuccin_window_current_middle_separator}"
     set -agF window-status-current-format \
       "#{E:@_ctp_w_text_style}#{@catppuccin_window_current_text}#{@_ctp_w_flags}#{E:@catppuccin_window_current_right_separator}"
   %else
     set -gF window-status-current-format \
-      "#{E:@_ctp_w_text_style}#{E:@catppuccin_window_left_separator}#{E:@_ctp_w_text_style}#{@catppuccin_window_current_text}#{@_ctp_w_flags}"
+      "#{E:@_ctp_w_text_style}#{E:@catppuccin_window_current_left_separator}#{E:@_ctp_w_text_style}#{@catppuccin_window_current_text}#{@_ctp_w_flags}"
     set -agF window-status-current-format "#{E:@catppuccin_window_current_middle_separator}"
     set -agF window-status-current-format \
       "#{E:@_ctp_w_number_style} #{@catppuccin_window_current_number}#{E:@catppuccin_window_current_right_separator}"


### PR DESCRIPTION
Use `catppuccin_window_current_left_separator` instead of `catppuccin_window_left_separator` when constructing the `window-status-current-style` option.

Previously, #443 fixed the unused `catppuccin_window_current_right_separator`, but `catppuccin_window_current_left_separator` remained unused. This PR addresses the left variable.