### PR TITLE
fix(flags): remove additional space from flags

### DIFF
--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -58,7 +58,7 @@ set -ogq @catppuccin_window_flags_icon_silent " 󰂛" # ~
 set -ogq @catppuccin_window_flags_icon_activity " 󱅫" # #
 set -ogq @catppuccin_window_flags_icon_bell " 󰂞" # !
 # Matches icon order when using `#F` (`#!~[*-]MZ`)
-set -ogq @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},}"
+set -ogq @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},} "
 
 # Status line options
 set -ogq @catppuccin_status_left_separator ""

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -168,7 +168,7 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
   set -gF window-status-bell-style "bg=#{@thm_yellow},fg=#{@thm_crust}"
 
    %if "#{==:#{@catppuccin_window_flags},icon}"
-    set -gqF @_ctp_w_flags "#{E:@catppuccin_window_flags_icon_format} "
+    set -gqF @_ctp_w_flags "#{E:@catppuccin_window_flags_icon_format}"
   %elif "#{==:#{@catppuccin_window_flags},text}"
     set -gq @_ctp_w_flags "#F"
   %else

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -104,7 +104,7 @@ set -ogq @catppuccin_window_flags_icon_silent " 󰂛" # ~
 set -ogq @catppuccin_window_flags_icon_activity " 󱅫" # #
 set -ogq @catppuccin_window_flags_icon_bell " 󰂞" # !
 # Matches icon order when using `#F` (`#!~[*-]MZ`)
-set -ogq @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},}"
+set -ogq @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},} "
 
 # Status line options
 set -ogq @catppuccin_status_left_separator ""


### PR DESCRIPTION
This effectively lets users decide if they want an additional space, instead of it being hard-coded