### PR TITLE
docs: change recommended default config, so that window names are automatically set (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ set -ag status-right "#{E:@catppuccin_status_session}"
 set -ag status-right "#{E:@catppuccin_status_uptime}"
 set -agF status-right "#{E:@catppuccin_status_battery}"
 
+# automatically set CWD as window name
+set -g @catppuccin_window_default_text "#W"
+set -g @catppuccin_window_current_text "#W"
+set -g @catppuccin_window_text "#W"
+set-option -g automatic-rename on
+set-option -g automatic-rename-format '#I #{b:pane_current_path}'
+
 run ~/.config/tmux/plugins/tmux-plugins/tmux-cpu/cpu.tmux
 run ~/.config/tmux/plugins/tmux-plugins/tmux-battery/battery.tmux
 # Or, if using TPM, just run TPM

--- a/docs/tutorials/01-getting-started.md
+++ b/docs/tutorials/01-getting-started.md
@@ -41,6 +41,13 @@ run ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux
 set -g status-left ""
 set -g status-right '#[fg=#{@thm_crust},bg=#{@thm_teal}] session: #S '
 
+# automatically set CWD as window name
+set -g @catppuccin_window_default_text "#W"
+set -g @catppuccin_window_current_text "#W"
+set -g @catppuccin_window_text "#W"
+set-option -g automatic-rename on
+set-option -g automatic-rename-format '#I #{b:pane_current_path}'
+
 # Ensure that everything on the right side of the status line
 # is included.
 set -g status-right-length 100


### PR DESCRIPTION
The docs state that if the recommended default config is applied, tmux windows are automatically renamed according to the CWD. But as discussed in https://github.com/catppuccin/tmux/issues/53, this is currently not the case. This PR updates the recommended default config, to align it with what the docs say.