### PR TITLE
docs: fix code block indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Check out what to do next in the "[Getting Started Guide](./docs/tutorials/01-ge
 
 1.  (Optional) Set your preferred flavor, it defaults to `"mocha"`:
 
-        ```bash
-        set -g @catppuccin_flavor 'mocha' # latte, frappe, macchiato or mocha
-        ```
+     ```bash
+     set -g @catppuccin_flavor 'mocha' # latte, frappe, macchiato or mocha
+     ```
 
     <!-- x-release-please-end -->
 


### PR DESCRIPTION
This PR fixes a small indentation issue in the README. It currently includes the literal characters for a code block when copying the command: 


![image](https://github.com/user-attachments/assets/b721c3b1-8deb-4494-8c54-0e784eb93759)
