### PR TITLE
docs: Correct the plugin path for TPM in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ set -g @catppuccin_window_status_style "rounded"
 
 # Load catppuccin
 run ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux
-# For TPM, instead use `run ~/.config/tmux/plugins/tmux/catppuccin.tmux`
+# For TPM, instead use `run ~/.tmux/plugins/tmux/catppuccin.tmux`
 
 # Make the status line pretty and add some modules
 set -g status-right-length 100


### PR DESCRIPTION
Correct the plugin path for TPM in the readme. Fixes #476 

[TPM](https://github.com/tmux-plugins/tpm) recommends the directory `~/.tmux/plugins/tpm` be used as the installation directory in the README, which is likely what most users will choose. TPM can be installed into _any_ directory, but the readme should ideally mention the most common choice that users will have, which we can assume is going to be `~/.tmux/plugins`.

---

Tested this change on my  [current setup](https://github.com/ThomasCode92/dotfiles/blob/main/dot_tmux.conf), see screenshot below.

![image](https://github.com/user-attachments/assets/e2f3088b-51db-448d-89db-4bbe9b318b8e)
