### PR TITLE
Add a "reset" option that will reset all options when loading the plugin

### DIFF
--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -3,6 +3,80 @@
 # This is executed separately to the main configuration
 # so that options are set before parsing the rest of the config.
 
+# Reset everything if requested.
+#
+# Useful for auto switching between themes:
+#
+# set-hook -g client-dark-theme {
+#   set -g @catppuccin_flavor "frappe"
+#   set -g @catppuccin_reset "true"
+#   run ~/code/github.com/catppuccin/tmux/catppuccin.tmux
+# }
+# set-hook -g client-light-theme {
+#   set -g @catppuccin_flavor "latte"
+#   set -g @catppuccin_reset "true"
+#   run ~/code/github.com/catppuccin/tmux/catppuccin.tmux
+# }
+%if "#{==:#{@catppuccin_reset},true}"
+set -Ugq @thm_bg
+set -Ugq @thm_fg
+set -Ugq @thm_rosewater
+set -Ugq @thm_flamingo
+set -Ugq @thm_rosewater
+set -Ugq @thm_pink
+set -Ugq @thm_mauve
+set -Ugq @thm_red
+set -Ugq @thm_maroon
+set -Ugq @thm_peach
+set -Ugq @thm_yellow
+set -Ugq @thm_green
+set -Ugq @thm_teal
+set -Ugq @thm_sky
+set -Ugq @thm_sapphire
+set -Ugq @thm_blue
+set -Ugq @thm_lavender
+set -Ugq @thm_subtext_1
+set -Ugq @thm_subtext_0
+set -Ugq @thm_overlay_2
+set -Ugq @thm_overlay_1
+set -Ugq @thm_overlay_0
+set -Ugq @thm_surface_2
+set -Ugq @thm_surface_1
+set -Ugq @thm_surface_0
+set -Ugq @thm_mantle
+set -Ugq @thm_crust
+set -Ugq @catppuccin_window_status_style
+set -Ugq @catppuccin_window_text_color
+set -Ugq @catppuccin_window_number_color
+set -Ugq @catppuccin_window_text
+set -Ugq @catppuccin_window_number
+set -Ugq @catppuccin_window_current_text_color
+set -Ugq @catppuccin_window_current_number_color
+set -Ugq @catppuccin_window_current_text
+set -Ugq @catppuccin_window_current_number
+set -Ugq @catppuccin_window_number_position
+set -Ugq @catppuccin_window_flags
+set -Ugq @catppuccin_window_flags_icon_last
+set -Ugq @catppuccin_window_flags_icon_current
+set -Ugq @catppuccin_window_flags_icon_zoom
+set -Ugq @catppuccin_window_flags_icon_mark
+set -Ugq @catppuccin_window_flags_icon_silent
+set -Ugq @catppuccin_window_flags_icon_activity
+set -Ugq @catppuccin_window_flags_icon_bell
+set -Ugq @catppuccin_window_flags_icon_format
+set -Ugq @catppuccin_status_left_separator
+set -Ugq @catppuccin_status_middle_separator
+set -Ugq @catppuccin_status_right_separator
+set -Ugq @catppuccin_status_connect_separator
+set -Ugq @catppuccin_status_module_text_bg
+set -Ugq @catppuccin_window_current_left_separator
+set -Ugq @catppuccin_window_current_middle_separator
+set -Ugq @catppuccin_window_current_right_separator
+
+# Finally reset the reset option.
+set -Ug @catppuccin_reset
+%endif
+
 set -ogq @catppuccin_flavor "mocha"
 
 set -ogq @catppuccin_status_background "default"

--- a/foo.conf
+++ b/foo.conf
@@ -1,0 +1,3 @@
+%if "#{==:$USER_THEME,}"
+  source "~/scripts/tmux/$USER_THEME.conf"
+%endif


### PR DESCRIPTION
This only works with a super recent tmux change: https://github.com/tmux/tmux/pull/4353

Will document how it works when the next major version of tmux is released