### PR TITLE
fix: load status panel according to tmux suggestions

### DIFF
--- a/docs/reference/status-line.md
+++ b/docs/reference/status-line.md
@@ -153,19 +153,12 @@ run '~/.tmux/plugins/tpm/tpm'
 
 ## Load module
 
-**Requirements:** This module depends on [tmux-loadavg](https://github.com/jamesoff/tmux-loadavg).
-
-**Install:** The preferred way to install tmux-loadavg is using [TPM](https://github.com/tmux-plugins/tpm).
-
 **Configure:**
 
 ```sh
 run ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux
 
 set -agF status-right "#{E:@catppuccin_status_load}"
-
-set -g @plugin 'jamesoff/tmux-loadavg'
-run '~/.tmux/plugins/tpm/tpm'
 ```
 
 ## Gitmux module
@@ -192,20 +185,20 @@ Add the following to your `~/.gitmux.conf` so that it uses catppuccin colors:
 
 ```yaml
 tmux:
-    styles:
-        clear: '#[fg=#{@thm_fg}]'
-        state: '#[fg=#{@thm_red},bold]'
-        branch: '#[fg=#{@thm_fg},bold]'
-        remote: '#[fg=#{@thm_teal}]'
-        divergence: '#[fg=#{@thm_fg}]'
-        staged: '#[fg=#{@thm_green},bold]'
-        conflict: '#[fg=#{@thm_red},bold]'
-        modified: '#[fg=#{@thm_yellow},bold]'
-        untracked: '#[fg=#{@thm_mauve},bold]'
-        stashed: '#[fg=#{@thm_blue},bold]'
-        clean: '#[fg=#{@thm_rosewater},bold]'
-        insertions: '#[fg=#{@thm_green}]'
-        deletions: '#[fg=#{@thm_red}]'
+  styles:
+    clear: "#[fg=#{@thm_fg}]"
+    state: "#[fg=#{@thm_red},bold]"
+    branch: "#[fg=#{@thm_fg},bold]"
+    remote: "#[fg=#{@thm_teal}]"
+    divergence: "#[fg=#{@thm_fg}]"
+    staged: "#[fg=#{@thm_green},bold]"
+    conflict: "#[fg=#{@thm_red},bold]"
+    modified: "#[fg=#{@thm_yellow},bold]"
+    untracked: "#[fg=#{@thm_mauve},bold]"
+    stashed: "#[fg=#{@thm_blue},bold]"
+    clean: "#[fg=#{@thm_rosewater},bold]"
+    insertions: "#[fg=#{@thm_green}]"
+    deletions: "#[fg=#{@thm_red}]"
 ```
 
 ## Pomodoro module

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,4 +10,5 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/application_module.sh --expected "${script_dir}"/tests/application_module_expected.txt "$@"
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/battery_module.sh --expected "${script_dir}"/tests/battery_module_expected.txt "$@"
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/cpu_module.sh --expected "${script_dir}"/tests/cpu_module_expected.txt "$@"
+"${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/load_module.sh --expected "${script_dir}"/tests/load_module_expected.txt "$@"
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/pane_styling.sh --expected "${script_dir}"/tests/pane_styling_expected.txt "$@"

--- a/status/load.conf
+++ b/status/load.conf
@@ -3,6 +3,6 @@
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊚 "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
-set -ogq "@catppuccin_${MODULE_NAME}_text" "#(uptime | awk '{split(substr($0, index($0, \"load\")), a, \":\"); print a[2]}')"
+set -ogq "@catppuccin_${MODULE_NAME}_text" " #(uptime | awk '{split(substr($0, index($0, \"load\")), a, \":\"); print a[2]}')"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/load.conf
+++ b/status/load.conf
@@ -3,6 +3,6 @@
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊚 "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
-set -ogq "@catppuccin_${MODULE_NAME}_text" " #(uptime | awk '{split(substr($0, index($0, \"load\")), a, \":\"); print a[2]}')"
+set -ogq "@catppuccin_${MODULE_NAME}_text" "#{l:#(uptime | awk '{split(substr($0, index($0, \"load\")), a, \":\"); print a[2]\}}')"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/load.conf
+++ b/status/load.conf
@@ -3,6 +3,6 @@
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊚 "
 set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
-set -ogq "@catppuccin_${MODULE_NAME}_text" " #{load_full}"
+set -ogq "@catppuccin_${MODULE_NAME}_text" "#(uptime | awk '{split(substr($0, index($0, \"load\")), a, \":\"); print a[2]}')"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/tests/load_module.sh
+++ b/tests/load_module.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+# shellcheck disable=SC1091
+source "${script_dir}/helpers.sh"
+
+# Tests that the default options are set correctly
+tmux source "${script_dir}/../catppuccin_options_tmux.conf"
+tmux source "${script_dir}/../catppuccin_tmux.conf"
+
+print_option E:@catppuccin_status_load

--- a/tests/load_module_expected.txt
+++ b/tests/load_module_expected.txt
@@ -1,2 +1,3 @@
 
-E:@catppuccin_status_load #[fg=#8aadf4]#[fg=#181926,bg=#8aadf4]󰊚 #[fg=#cad3f5,bg=#363a4f]#[fg=#363a4f] 
+E:@catppuccin_status_load #[fg=#89b4fa]#[fg=#11111b,bg=#89b4fa]󰊚 #[fg=#cdd6f4,bg=#313244]#(uptime | awk '{split(substr($0, index($0, "load")), a, ":"); print a[2]}')#[fg=#313244]
+

--- a/tests/load_module_expected.txt
+++ b/tests/load_module_expected.txt
@@ -1,0 +1,2 @@
+
+E:@catppuccin_status_load #[fg=#8aadf4]#[fg=#181926,bg=#8aadf4]󰊚 #[fg=#cad3f5,bg=#363a4f]#[fg=#363a4f] 


### PR DESCRIPTION
Fixed load status as per [PR 503](https://github.com/catppuccin/tmux/pull/503).
Used `uptime|awk '{split(substr($0, index($0, "load")), a, ":"); print a[2]}'` to set the text variable as suggested [here](https://github.com/tmux/tmux/wiki/FAQ#what-is-the-best-way-to-display-the-load-average-why-no-l).
