### PR TITLE
docs: stop recommending `-o`

### DIFF
--- a/catppuccin_options_tmux.conf
+++ b/catppuccin_options_tmux.conf
@@ -3,6 +3,7 @@
 # This is executed separately to the main configuration
 # so that options are set before parsing the rest of the config.
 
+# DO NOT USE -o IN YOUR OWN CONFIGURATION
 set -ogq @catppuccin_flavor "mocha"
 
 set -ogq @catppuccin_status_background "default"
@@ -10,7 +11,7 @@ set -ogq @catppuccin_status_background "default"
 # Menu styling options
 set -ogq @catppuccin_menu_selected_style "fg=#{@thm_fg},bold,bg=#{@thm_overlay_0}"
 
-# Pane styling options
+# Pane styling options (DO NOT USE -o IN YOUR OWN CONFIGURATION)
 set -ogq @catppuccin_pane_status_enabled "no" # set to "yes" to enable
 set -ogq @catppuccin_pane_border_status "off" # set to "yes" to enable
 set -ogq @catppuccin_pane_border_style "fg=#{@thm_overlay_0}"
@@ -36,7 +37,7 @@ set -ogq @catppuccin_pane_number_position "left" # right, left
 # @catppuccin_window_default_fill, @catppuccin_window_current_fill
 # Just set the number and text colors.
 
-# Window options
+# Window options (DO NOT USE -o IN YOUR OWN CONFIGURATION)
 set -ogq @catppuccin_window_status_style "basic" # basic, rounded, slanted, custom, or none
 set -ogq @catppuccin_window_text_color "#{@thm_surface_0}"
 set -ogq @catppuccin_window_number_color "#{@thm_overlay_2}"
@@ -60,7 +61,7 @@ set -ogq @catppuccin_window_flags_icon_bell " 󰂞" # !
 # Matches icon order when using `#F` (`#!~[*-]MZ`)
 set -ogq @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},} "
 
-# Status line options
+# Status line options (DO NOT USE -o IN YOUR OWN CONFIGURATION)
 set -ogq @catppuccin_status_left_separator ""
 set -ogq @catppuccin_status_middle_separator ""
 set -ogq @catppuccin_status_right_separator " "

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -158,6 +158,7 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
 
 %endif
 
+# DO NOT USE -o IN YOUR OWN CONFIGURATION
 set -ogqF @catppuccin_window_current_left_separator "#{@catppuccin_window_left_separator}"
 set -ogqF @catppuccin_window_current_middle_separator "#{@catppuccin_window_middle_separator}"
 set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right_separator}"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -69,48 +69,48 @@ set -g @catppuccin_menu_selected_style "fg=#{@thm_surface_0},bg=#{@thm_yellow}"
 
 ```bash
 # Menu styling options
-set -ogq @catppuccin_menu_selected_style "fg=#{@thm_fg},bold,bg=#{@thm_overlay_0}"
+set -g @catppuccin_menu_selected_style "fg=#{@thm_fg},bold,bg=#{@thm_overlay_0}"
 
 # Pane styling options
-set -ogq @catppuccin_pane_status_enabled "no" # set to "yes" to enable
-set -ogq @catppuccin_pane_border_status "off" # set to "yes" to enable
-set -ogq @catppuccin_pane_border_style "fg=#{@thm_overlay_0}"
-set -ogq @catppuccin_pane_active_border_style "##{?pane_in_mode,fg=#{@thm_lavender},##{?pane_synchronized,fg=#{@thm_mauve},fg=#{@thm_lavender}}}"
-set -ogq @catppuccin_pane_left_separator "█"
-set -ogq @catppuccin_pane_middle_separator "█"
-set -ogq @catppuccin_pane_right_separator "█"
-set -ogq @catppuccin_pane_color "#{@thm_green}"
-set -ogq @catppuccin_pane_background_color "#{@thm_surface_0}"
-set -ogq @catppuccin_pane_default_text "##{b:pane_current_path}"
-set -ogq @catppuccin_pane_default_fill "number"
-set -ogq @catppuccin_pane_number_position "left" # right, left
+set -g @catppuccin_pane_status_enabled "no" # set to "yes" to enable
+set -g @catppuccin_pane_border_status "off" # set to "yes" to enable
+set -g @catppuccin_pane_border_style "fg=#{@thm_overlay_0}"
+set -g @catppuccin_pane_active_border_style "##{?pane_in_mode,fg=#{@thm_lavender},##{?pane_synchronized,fg=#{@thm_mauve},fg=#{@thm_lavender}}}"
+set -g @catppuccin_pane_left_separator "█"
+set -g @catppuccin_pane_middle_separator "█"
+set -g @catppuccin_pane_right_separator "█"
+set -g @catppuccin_pane_color "#{@thm_green}"
+set -g @catppuccin_pane_background_color "#{@thm_surface_0}"
+set -g @catppuccin_pane_default_text "##{b:pane_current_path}"
+set -g @catppuccin_pane_default_fill "number"
+set -g @catppuccin_pane_number_position "left" # right, left
 
-set -ogq @catppuccin_window_status_style "basic" # basic, rounded, slanted, custom, or none
-set -ogq @catppuccin_window_text_color "#{@thm_surface_0}"
-set -ogq @catppuccin_window_number_color "#{@thm_overlay_2}"
-set -ogq @catppuccin_window_text " #T"
-set -ogq @catppuccin_window_number "#I"
-set -ogq @catppuccin_window_current_text_color "#{@thm_surface_1}"
-set -ogq @catppuccin_window_current_number_color "#{@thm_mauve}"
-set -ogq @catppuccin_window_current_text " #T"
-set -ogq @catppuccin_window_current_number "#I"
-set -ogq @catppuccin_window_number_position "left"
-set -ogq @catppuccin_window_flags "none" # none, icon, or text
-set -ogq @catppuccin_window_flags_icon_last " 󰖰" # -
-set -ogq @catppuccin_window_flags_icon_current " 󰖯" # *
-set -ogq @catppuccin_window_flags_icon_zoom " 󰁌" # Z
-set -ogq @catppuccin_window_flags_icon_mark " 󰃀" # M
-set -ogq @catppuccin_window_flags_icon_silent " 󰂛" # ~
-set -ogq @catppuccin_window_flags_icon_activity " 󱅫" # #
-set -ogq @catppuccin_window_flags_icon_bell " 󰂞" # !
+set -g @catppuccin_window_status_style "basic" # basic, rounded, slanted, custom, or none
+set -g @catppuccin_window_text_color "#{@thm_surface_0}"
+set -g @catppuccin_window_number_color "#{@thm_overlay_2}"
+set -g @catppuccin_window_text " #T"
+set -g @catppuccin_window_number "#I"
+set -g @catppuccin_window_current_text_color "#{@thm_surface_1}"
+set -g @catppuccin_window_current_number_color "#{@thm_mauve}"
+set -g @catppuccin_window_current_text " #T"
+set -g @catppuccin_window_current_number "#I"
+set -g @catppuccin_window_number_position "left"
+set -g @catppuccin_window_flags "none" # none, icon, or text
+set -g @catppuccin_window_flags_icon_last " 󰖰" # -
+set -g @catppuccin_window_flags_icon_current " 󰖯" # *
+set -g @catppuccin_window_flags_icon_zoom " 󰁌" # Z
+set -g @catppuccin_window_flags_icon_mark " 󰃀" # M
+set -g @catppuccin_window_flags_icon_silent " 󰂛" # ~
+set -g @catppuccin_window_flags_icon_activity " 󱅫" # #
+set -g @catppuccin_window_flags_icon_bell " 󰂞" # !
 # Matches icon order when using `#F` (`#!~[*-]MZ`)
-set -ogq @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},} "
+set -g @catppuccin_window_flags_icon_format "##{?window_activity_flag,#{E:@catppuccin_window_flags_icon_activity},}##{?window_bell_flag,#{E:@catppuccin_window_flags_icon_bell},}##{?window_silence_flag,#{E:@catppuccin_window_flags_icon_silent},}##{?window_active,#{E:@catppuccin_window_flags_icon_current},}##{?window_last_flag,#{E:@catppuccin_window_flags_icon_last},}##{?window_marked_flag,#{E:@catppuccin_window_flags_icon_mark},}##{?window_zoomed_flag,#{E:@catppuccin_window_flags_icon_zoom},} "
 
 # Status line options
-set -ogq @catppuccin_status_left_separator ""
-set -ogq @catppuccin_status_middle_separator ""
-set -ogq @catppuccin_status_right_separator "█"
-set -ogq @catppuccin_status_connect_separator "yes" # yes, no
-set -ogq @catppuccin_status_fill "icon"
-set -ogq @catppuccin_status_module_bg_color "#{@thm_surface_0}"
+set -g @catppuccin_status_left_separator ""
+set -g @catppuccin_status_middle_separator ""
+set -g @catppuccin_status_right_separator "█"
+set -g @catppuccin_status_connect_separator "yes" # yes, no
+set -g @catppuccin_status_fill "icon"
+set -g @catppuccin_status_module_bg_color "#{@thm_surface_0}"
 ```

--- a/docs/tutorials/02-custom-status.md
+++ b/docs/tutorials/02-custom-status.md
@@ -31,9 +31,9 @@ To use the status module formatting that catppuccin uses, do the following:
 
 %hidden MODULE_NAME="my_custom_module"
 
-set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_pink}"
-set -ogq "@catppuccin_${MODULE_NAME}_text" "#{pane_current_command}"
+set -g "@catppuccin_${MODULE_NAME}_icon" " "
+set -gF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_pink}"
+set -g "@catppuccin_${MODULE_NAME}_text" "#{pane_current_command}"
 
 source "<path to catppuccin plugin>/utils/status_module.conf"
 


### PR DESCRIPTION
Recurring issues are being raised that options are not being applied,
where users have used '-o' to set options. '-o' instructs tmux
to only set the option if it is not already set. This is useful
in the plugin itself, but almost never useful for the end user.