### PR TITLE
fix(status): change tmux plugin for kube module

### DIFF
--- a/docs/reference/status-line.md
+++ b/docs/reference/status-line.md
@@ -220,9 +220,9 @@ run '~/.tmux/plugins/tpm/tpm'
 
 ## Kube module
 
-**Requirements:** This module depends on [kube-tmux](https://github.com/jonmosco/kube-tmux).
+**Requirements:** This module depends on [tmux-kubectx](https://github.com/tony-sol/tmux-kubectx).
 
-**Install:** The preferred way to install kube-tmux is using [TPM](https://github.com/tmux-plugins/tpm).
+**Install:** The preferred way to install tmux-kubectx is using [TPM](https://github.com/tmux-plugins/tpm).
 
 **Configure:**
 
@@ -234,6 +234,6 @@ run ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux
 
 set -agF status-right "#{E:@catppuccin_status_kube}"
 
-set -g @plugin 'jonmosco/kube-tmux'
+set -g @plugin 'tony-sol/tmux-kubectx'
 run '~/.tmux/plugins/tpm/tpm'
 ```

--- a/status/kube.conf
+++ b/status/kube.conf
@@ -8,6 +8,6 @@ set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
 set -ogqF "@catppuccin_kube_context_color" "#{E:@thm_red}"
 set -ogqF "@catppuccin_kube_namespace_color" "#{E:@thm_sky}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" \
-   " #(\${TMUX_PLUGIN_MANAGER_PATH}kube-tmux/kube.tmux 250 #{@catppuccin_kube_context_color} #{@catppuccin_kube_namespace_color})"
+   " #{l:#[fg=#{@catppuccin_kube_context_color}]#{kubectx_context}#[fg=default]:#[fg=#{@catppuccin_kube_namespace_color}]#{kubectx_namespace}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"


### PR DESCRIPTION
Fixed the kube module by doing the following:

related to #459

* Replaced `jonmosco/kube-tmux` with `tony-sol/tmux-kubectx` as the
former was incorrectly formatting the tmux output and doesn't look to be
maintained at all anymore.
* Updated the Kube Module's documentation to account for the change in
tmux plugin being used.

Example: 
![image](https://github.com/user-attachments/assets/3da67691-5d29-492a-a6dd-c2c5320e9d8b)

