### PR TITLE
docs: status-line left/right mixup

### DIFF
--- a/docs/reference/status-line.md
+++ b/docs/reference/status-line.md
@@ -59,10 +59,10 @@ set -g @catppuccin_date_time_icon ""
 ### Notes for TPM users
 
 Make sure you load the catppuccin theme prior to setting the status-left and/or
-status-left options. This ensures the catppuccin options (such as colors and
+status-right options. This ensures the catppuccin options (such as colors and
 status modules) are defined so they can then be used.
 
-After status-left and/or status-left have been set, make sure to run TPM to load
+After status-left and/or status-right have been set, make sure to run TPM to load
 the modules. This runs any plugins that may replace text in the status line.
 
 ```bash


### PR DESCRIPTION
Fixed a text duplication error for status-left/status-right.