### PR TITLE
Fix broken days unit in statusline uptime module

### DIFF
--- a/status/uptime.conf
+++ b/status/uptime.conf
@@ -3,6 +3,6 @@
 
 set -ogq @catppuccin_uptime_icon "󰔟 "
 set -ogqF @catppuccin_uptime_color "#{E:@thm_sapphire}"
-set -ogq @catppuccin_uptime_text " #(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/ hr\\(s*\\).*/h/; s/ min\\(s*\\).*/m/; s/ sec\\(s*\\).*/s/; s/\\([0-9]\\{1,2\\}\\):\\([0-9]\\{1,2\\}\\)/\\1h \\2m/;')"
+set -ogq @catppuccin_uptime_text " #(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.* /d /; s/ hr\\(s*\\).*/h/; s/ min\\(s*\\).*/m/; s/ sec\\(s*\\).*/s/; s/\\([0-9]\\{1,2\\}\\):\\([0-9]\\{1,2\\}\\)/\\1h \\2m/;')"
 
 source -F "#{d:current_file}/../utils/status_module.conf"


### PR DESCRIPTION
Fixes an error in the `sed` regex which `uptime` is piped to that causes days to be parsed incorrectly. Tested against both uutils and macOS `uptime`.