### PR TITLE
Correct documentation for custom module

### DIFF
--- a/docs/tutorials/02-custom-status.md
+++ b/docs/tutorials/02-custom-status.md
@@ -27,7 +27,7 @@ set -ag status-right "#[fg=#{@thm_fg},bg=#{@thm_mantle}] #(memory_pressure | awk
 To use the status module formatting that catppuccin uses, do the following:
 
 ```sh
-# In ~/.tmux.conf, after the catppuccin plugin has been loaded.
+# In ~/.tmux.conf, before the catppuccin plugin has been loaded.
 
 %hidden MODULE_NAME="my_custom_module"
 


### PR DESCRIPTION
I spent ages trying to figure out why my custom module wasn't being loaded. Tuned out I had to define it and source `status_module.conf` **BEFORE** running `catppuccin.tmux`