### PR TITLE
fix(theme): Cleanup duplicate palette theme color

### DIFF
--- a/themes/catppuccin_frappe_tmux.conf
+++ b/themes/catppuccin_frappe_tmux.conf
@@ -7,7 +7,6 @@ set -ogq @thm_fg "#c6d0f5"
 # Colors
 set -ogq @thm_rosewater "#f2d5cf"
 set -ogq @thm_flamingo "#eebebe"
-set -ogq @thm_rosewater "#f2d5cf"
 set -ogq @thm_pink "#f4b8e4"
 set -ogq @thm_mauve "#ca9ee6"
 set -ogq @thm_red "#e78284"

--- a/themes/catppuccin_latte_tmux.conf
+++ b/themes/catppuccin_latte_tmux.conf
@@ -7,7 +7,6 @@ set -ogq @thm_fg "#4c4f69"
 # Colors
 set -ogq @thm_rosewater "#dc8a78"
 set -ogq @thm_flamingo "#dd7878"
-set -ogq @thm_rosewater "#dc8a78"
 set -ogq @thm_pink "#ea76cb"
 set -ogq @thm_mauve "#8839ef"
 set -ogq @thm_red "#d20f39"

--- a/themes/catppuccin_macchiato_tmux.conf
+++ b/themes/catppuccin_macchiato_tmux.conf
@@ -7,7 +7,6 @@ set -ogq @thm_fg "#cad3f5"
 # Colors
 set -ogq @thm_rosewater "#f4dbd6"
 set -ogq @thm_flamingo "#f0c6c6"
-set -ogq @thm_rosewater "#f4dbd6"
 set -ogq @thm_pink "#f5bde6"
 set -ogq @thm_mauve "#c6a0f6"
 set -ogq @thm_red "#ed8796"

--- a/themes/catppuccin_mocha_tmux.conf
+++ b/themes/catppuccin_mocha_tmux.conf
@@ -7,7 +7,6 @@ set -ogq @thm_fg "#cdd6f4"
 # Colors
 set -ogq @thm_rosewater "#f5e0dc"
 set -ogq @thm_flamingo "#f2cdcd"
-set -ogq @thm_rosewater "#f5e0dc"
 set -ogq @thm_pink "#f5c2e7"
 set -ogq @thm_mauve "#cba6f7"
 set -ogq @thm_red "#f38ba8"


### PR DESCRIPTION
I'm not very familiar with tmux configuration or themes, let alone familiar with Catppuccin, so I'm not at all confident in this change, but this sure looked like unintentionally duplicated code, to I thought I'd fire off a PR. Feel free to reject for whatever reason.