### PR TITLE
Fix: Transparent status background support with rounded and slanted styles

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -136,29 +136,38 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
 
 %elif "#{==:#{@catppuccin_window_status_style},rounded}"
 
-  set -gq @catppuccin_window_left_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_text_color},bg=#{@catppuccin_window_number_color}]"
-  set -gq @catppuccin_window_current_left_separator "#[fg=#{@catppuccin_window_current_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_current_text_color},bg=#{@catppuccin_window_current_number_color}]"
   set -gq @catppuccin_window_middle_separator " "
-  set -gq @catppuccin_window_right_separator "#[fg=#{@catppuccin_window_text_color},bg=#{@_ctp_status_bg}]#[none]"
-  set -gq @catppuccin_window_current_right_separator "#[fg=#{@catppuccin_window_current_text_color},bg=#{@_ctp_status_bg}]#[none]"
+  %if "#{==:#{@catppuccin_window_number_position},left}"
+    set -gq @catppuccin_window_left_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_text_color},bg=#{@catppuccin_window_number_color}]"
+    set -gq @catppuccin_window_current_left_separator "#[fg=#{@catppuccin_window_current_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_current_text_color},bg=#{@catppuccin_window_current_number_color}]"
+    set -gq @catppuccin_window_right_separator "#[fg=#{@catppuccin_window_text_color},bg=#{@_ctp_status_bg}]#[none]"
+    set -gq @catppuccin_window_current_right_separator "#[fg=#{@catppuccin_window_current_text_color},bg=#{@_ctp_status_bg}]#[none]"
+  %else
+    set -gq @catppuccin_window_left_separator "#[fg=#{@catppuccin_window_text_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_text_color},bg=#{@catppuccin_window_number_color}]"
+    set -gq @catppuccin_window_current_left_separator "#[fg=#{@catppuccin_window_current_text_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_current_text_color},bg=#{@catppuccin_window_current_number_color}]"
+    set -gq @catppuccin_window_right_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@_ctp_status_bg}]#[none]"
+    set -gq @catppuccin_window_current_right_separator "#[fg=#{@catppuccin_window_current_number_color},bg=#{@_ctp_status_bg}]#[none]"
+  %endif
 
 %elif "#{==:#{@catppuccin_window_status_style},slanted}"
 
-  set -gq @catppuccin_window_left_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_text_color},bg=#{@catppuccin_window_number_color}]"
-  set -gq @catppuccin_window_current_left_separator "#[fg=#{@catppuccin_window_current_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_current_text_color},bg=#{@catppuccin_window_current_number_color}]"
-
   %if "#{==:#{@catppuccin_window_number_position},left}"
+    set -gq @catppuccin_window_left_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_text_color},bg=#{@catppuccin_window_number_color}]"
+    set -gq @catppuccin_window_current_left_separator "#[fg=#{@catppuccin_window_current_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_current_text_color},bg=#{@catppuccin_window_current_number_color}]"
     set -gq @catppuccin_window_middle_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@catppuccin_window_text_color}]"
     set -gq @catppuccin_window_current_middle_separator \
       "#[fg=#{@catppuccin_window_current_number_color},bg=#{@catppuccin_window_current_text_color}]"
+    set -gq @catppuccin_window_right_separator "#[fg=#{@catppuccin_window_text_color},bg=#{@_ctp_status_bg}]█#[none]"
+    set -gq @catppuccin_window_current_right_separator "#[fg=#{@catppuccin_window_current_text_color},bg=#{@_ctp_status_bg}]█#[none]"
   %else
+    set -gq @catppuccin_window_left_separator "#[fg=#{@catppuccin_window_text_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_text_color},bg=#{@catppuccin_window_number_color}]"
+    set -gq @catppuccin_window_current_left_separator "#[fg=#{@catppuccin_window_current_text_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_current_text_color},bg=#{@catppuccin_window_current_number_color}]"
     set -gq @catppuccin_window_middle_separator " #[fg=#{@catppuccin_window_number_color},bg=#{@catppuccin_window_text_color}]"
     set -gq @catppuccin_window_current_middle_separator \
       " #[fg=#{@catppuccin_window_current_number_color},bg=#{@catppuccin_window_current_text_color}]"
+    set -gq @catppuccin_window_right_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@_ctp_status_bg}]█#[none]"
+    set -gq @catppuccin_window_current_right_separator "#[fg=#{@catppuccin_window_current_number_color},bg=#{@_ctp_status_bg}]█#[none]"
   %endif
-
-  set -gq @catppuccin_window_right_separator "#[fg=#{@catppuccin_window_text_color},bg=#{@_ctp_status_bg}]█#[none]"
-  set -gq @catppuccin_window_current_right_separator "#[fg=#{@catppuccin_window_current_text_color},bg=#{@_ctp_status_bg}]█#[none]"
 
 %endif
 

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -7,7 +7,7 @@ source -F "#{d:current_file}/themes/catppuccin_#{@catppuccin_flavor}_tmux.conf"
   %hidden CTP_MESSAGE_BACKGROUND="#{@thm_overlay_0}"
 %elif "#{==:#{@catppuccin_status_background},none}"
   set -g status-style "default"
-  set -g @_ctp_status_bg "none"
+  set -g @_ctp_status_bg "default"
 
   %hidden CTP_MESSAGE_BACKGROUND="default"
 %else

--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -136,13 +136,16 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
 
 %elif "#{==:#{@catppuccin_window_status_style},rounded}"
 
-  set -gq @catppuccin_window_left_separator "#[fg=#{@_ctp_status_bg},reverse]#[none]"
+  set -gq @catppuccin_window_left_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_text_color},bg=#{@catppuccin_window_number_color}]"
+  set -gq @catppuccin_window_current_left_separator "#[fg=#{@catppuccin_window_current_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_current_text_color},bg=#{@catppuccin_window_current_number_color}]"
   set -gq @catppuccin_window_middle_separator " "
-  set -gq @catppuccin_window_right_separator "#[fg=#{@_ctp_status_bg},reverse]#[none]"
+  set -gq @catppuccin_window_right_separator "#[fg=#{@catppuccin_window_text_color},bg=#{@_ctp_status_bg}]#[none]"
+  set -gq @catppuccin_window_current_right_separator "#[fg=#{@catppuccin_window_current_text_color},bg=#{@_ctp_status_bg}]#[none]"
 
 %elif "#{==:#{@catppuccin_window_status_style},slanted}"
 
-  set -gq @catppuccin_window_left_separator "#[fg=#{@_ctp_status_bg},reverse]#[none]"
+  set -gq @catppuccin_window_left_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_text_color},bg=#{@catppuccin_window_number_color}]"
+  set -gq @catppuccin_window_current_left_separator "#[fg=#{@catppuccin_window_current_number_color},bg=#{@_ctp_status_bg}]#[fg=#{@catppuccin_window_current_text_color},bg=#{@catppuccin_window_current_number_color}]"
 
   %if "#{==:#{@catppuccin_window_number_position},left}"
     set -gq @catppuccin_window_middle_separator "#[fg=#{@catppuccin_window_number_color},bg=#{@catppuccin_window_text_color}]"
@@ -154,7 +157,8 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
       " #[fg=#{@catppuccin_window_current_number_color},bg=#{@catppuccin_window_current_text_color}]"
   %endif
 
-  set -gq @catppuccin_window_right_separator "#[fg=#{@_ctp_status_bg},reverse]█#[none]"
+  set -gq @catppuccin_window_right_separator "#[fg=#{@catppuccin_window_text_color},bg=#{@_ctp_status_bg}]█#[none]"
+  set -gq @catppuccin_window_current_right_separator "#[fg=#{@catppuccin_window_current_text_color},bg=#{@_ctp_status_bg}]█#[none]"
 
 %endif
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -18,7 +18,6 @@ This is a diagram of how the theme is split between its components.
 
 - `default` will use the color from the selected theme
 - `none` will make the status bar transparent
-  - If you are using the `rounded` or `slanted` window styles, instead set a hex color code that your terminal will make transparent.
 - use hex color codes for other colors or a theme color (`#{@thm_<color>}`)
 
 ### Window

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -18,6 +18,7 @@ This is a diagram of how the theme is split between its components.
 
 - `default` will use the color from the selected theme
 - `none` will make the status bar transparent
+  - If you are using the `rounded` or `slanted` window styles, instead set a hex color code that your terminal will make transparent.
 - use hex color codes for other colors or a theme color (`#{@thm_<color>}`)
 
 ### Window


### PR DESCRIPTION
This is actually two fixes, which address [issue #409](https://github.com/catppuccin/tmux/issues/409). This PR is also an alternative to [pr #568](https://github.com/catppuccin/tmux/pull/568).
* Always use the status bg color as an actual background color (as opposed to a foreground color), so that terminals can make its color transparent and it works in rounded and slanted styles.
* Set the default bg color when `@catppuccin_status_background` is set to 'none', so that it works in rounded and slanted styles.

### Details

The [configuration documentation](https://github.com/catppuccin/tmux/blob/8b0b9150f9d7dee2a4b70cdb50876ba7fd6d674a/docs/reference/configuration.md#status-line) says to set `@catppuccin_status_background` to `none` to make the status bar transparent, but this doesn't work in the rounded or slanted window status styles. Attempting to work around the problem by setting it to the background color that the terminal is making transparent also doesn't work for the rounded or slanted styles.

These two similar issues have different causes:
1. While terminals can have a particular color chosen as the one to make transparent, it only works on background colors, and the existing configuration was using the status background color as a foreground color.
    * This PR's fix: Change the usage of `@catppuccin_status_background`'s value to only apply it as a background color, which allows users to set it to a background color that their terminal will make transparent.
2. Setting `@catppuccin_status_background` to `none` doesn't work due to how it internally sets `@_ctp_status_bg` to 'none', which isn't valid for tmux. In the tmux man page the value 'none' is referenced for clearing all formatting, but not as a valid value for a particular property like `bg` or `fg`. Instead, the man page has an example of 'default' being used for that.
    * This PR's fix: When the user sets `@catppuccin_status_background` to 'none', set the value of `@_ctp_status_bg` to 'default' instead of 'none', which tmux handles correctly.

I tested the changes in Wezterm primarily, but also checked that it works in Kitty and Ghostty.

### Comparison Screenshots

**Before** — background set to 'none'
<img width="1790" height="1320" alt="image" src="https://github.com/user-attachments/assets/6948169f-d29f-4ced-a28f-ab4660ae2095" />

**Before** — background set to terminal's transparent background color
<img width="1790" height="1320" alt="image" src="https://github.com/user-attachments/assets/678c1207-191b-411a-bd25-2dba054c9c47" />

**After** — either transparency method
<img width="1790" height="1320" alt="image" src="https://github.com/user-attachments/assets/81b35d01-0263-4728-9a9e-96b780afc4e4" />

**After** — non-transparent colors still work as expected, as shown here
<img width="1790" height="1320" alt="image" src="https://github.com/user-attachments/assets/1aa972c8-5c40-42da-aeb1-7c9df9fe8862" />