### PR TITLE
feat: update `mode-style` to `@thm_surface_1`.

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -221,5 +221,5 @@ set -ogqF @catppuccin_window_current_right_separator "#{@catppuccin_window_right
 %endif
 
 # Mode style. This is used for copy mode highlighting to style the current selection.
-set -gF mode-style "bg=#{@thm_surface_0},bold"
+set -gF mode-style "bg=#{@thm_surface_1},bold"
 set -gF clock-mode-colour "#{@thm_blue}"


### PR DESCRIPTION
Copy mode selection background (configured by the `mode-style` option) was previously set to `@thm_surface_0`, but this provides little contrast to the default background `@thm_bg`).

Other Catppuccin ports use `@thm_surface_1` as the selection background, which provides better contrast:

- https://github.com/catppuccin/vim/blob/fc2e9d853208621a94ec597c50bf559875bf6d99/colors/catppuccin_frappe.vim#L67
- https://github.com/catppuccin/nvim/blob/426dbebe06b5c69fd846ceb17b42e12f890aedf1/lua/catppuccin/groups/editor.lua#L93
- https://github.com/catppuccin/helix/blob/91e071bf9b9b2b8ae176a5581fcb61c789c55cab/helix.tera#L121