### PR TITLE
feat: update `popup-border-style` to `@thm_overlay_0`.

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -126,7 +126,7 @@ set -wgF pane-border-style "#{E:@catppuccin_pane_border_style}"
 # popups
 %if "#{>=:#{version},3.4}"
   set -gF popup-style "bg=#{@thm_bg},fg=#{@thm_fg}"
-  set -gF popup-border-style "fg=#{@thm_surface_1}"
+  set -gF popup-border-style "fg=#{@thm_overlay_0}"
 %endif
 
 %if "#{==:#{@catppuccin_window_status_style},basic}"


### PR DESCRIPTION
The previous popup border of `@thm_surface_1` is barely visible. Using `@thm_overlay_0` makes the borders consistent with the pane borders and with the style guide at
https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md#terminals.

Before:

<img width="1680" height="1017" alt="tmux-popup-border-surface1" src="https://github.com/user-attachments/assets/4278319d-f2d2-420a-8c7b-07a52b205c56" />

After:

<img width="1680" height="1017" alt="tmux-popup-border-overlay0" src="https://github.com/user-attachments/assets/14356b3c-2bce-4f1d-8cf1-a252771ea771" />
