### PR TITLE
fix: escape hex colors so they survive tmux next-3.7 format expansion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,28 @@ jobs:
           bash --version
           tmux -V
           ./run_tests.sh
+
+  # Advisory canary against tmux master; non-blocking by design.
+  tmux-master:
+    name: Test (tmux master)
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+
+    steps:
+      - name: Build tmux from master
+        run: |
+          sudo apt update
+          sudo apt install -y libevent-dev libncurses-dev bison autoconf automake pkg-config build-essential
+          git clone --depth 1 https://github.com/tmux/tmux.git /tmp/tmux-src
+          cd /tmp/tmux-src
+          sh autogen.sh
+          ./configure
+          make
+          sudo make install
+      - uses: actions/checkout@v6
+      - name: Run Tests
+        shell: bash
+        run: |
+          bash --version
+          tmux -V
+          ./run_tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,14 +34,14 @@ jobs:
           tmux -V
           ./run_tests.sh
 
-  # Advisory canary against tmux master; non-blocking by design.
-  tmux-master:
-    name: Test (tmux master)
+  # Advisory canary against tmux's default branch; non-blocking by design.
+  tmux-latest:
+    name: Test (tmux latest)
     runs-on: ubuntu-24.04
     continue-on-error: true
 
     steps:
-      - name: Build tmux from master
+      - name: Build tmux from default branch
         run: |
           sudo apt update
           sudo apt install -y libevent-dev libncurses-dev bison autoconf automake pkg-config build-essential

--- a/catppuccin.tmux
+++ b/catppuccin.tmux
@@ -5,3 +5,30 @@ PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 tmux source "${PLUGIN_DIR}/catppuccin_options_tmux.conf"
 tmux source "${PLUGIN_DIR}/catppuccin_tmux.conf"
+
+# Render-safe colors.
+#
+# tmux's format_expand1 (next-3.7+) treats a leading #1-#9 as positional-argument
+# shorthand, so expanding a format at render time eats the first digit of any
+# literal #RRGGBB hex (e.g. #15232d -> 5232d). Every option below is a format that
+# tmux expands at render time (per window/pane, or via the user's #{E:...} status
+# line), so a literal hex baked into one breaks.
+#
+# Escape every #RRGGBB to ##RRGGBB; the render then unescapes it back to an intact
+# #RRGGBB. Deferred references such as #{@thm_*} carry no literal and are left
+# untouched (they resolve normally). The pass is idempotent (unescape, then
+# escape), so it stays correct if an option is not rebuilt on reload.
+_ctp_formats="window-status-format window-status-current-format pane-border-format"
+for _ctp_module in application battery clima cpu date_time directory gitmux host \
+                   kube load pomodoro_plus ram session uptime user weather; do
+  _ctp_formats="${_ctp_formats} @catppuccin_status_${_ctp_module}"
+done
+
+for _ctp_opt in ${_ctp_formats}; do
+  _ctp_val="$(tmux show -gqv "${_ctp_opt}")"
+  [ -n "${_ctp_val}" ] &&
+    tmux set -g "${_ctp_opt}" \
+      "$(printf '%s' "${_ctp_val}" | sed -E 's/##([0-9a-fA-F]{6})/#\1/g; s/#([0-9a-fA-F]{6})/##\1/g')"
+done
+
+unset _ctp_formats _ctp_module _ctp_opt _ctp_val

--- a/status/application.conf
+++ b/status/application.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="application"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_maroon}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_maroon}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{pane_current_command}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/battery.conf
+++ b/status/battery.conf
@@ -16,7 +16,7 @@ set -ogq @batt_icon_status_unknown "󰂑"
 set -ogq @batt_icon_status_attached "󱈑"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "#{l:#{battery_icon}} "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_lavender}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_lavender}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{l:#{battery_percentage}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/clima.conf
+++ b/status/clima.conf
@@ -3,7 +3,7 @@
 %hidden MODULE_NAME="clima"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_yellow}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{l:#{clima}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/cpu.conf
+++ b/status/cpu.conf
@@ -1,16 +1,16 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="cpu"
 
-set -ogq @cpu_low_fg_color "#{E:@thm_fg}"
-set -ogq @cpu_medium_fg_color "#{E:@thm_fg}"
-set -ogq @cpu_high_fg_color "#{E:@thm_crust}"
+set -ogq @cpu_low_fg_color "#{@thm_fg}"
+set -ogq @cpu_medium_fg_color "#{@thm_fg}"
+set -ogq @cpu_high_fg_color "#{@thm_crust}"
 
 set -ogq @cpu_low_bg_color "#{E:@catppuccin_status_module_text_bg}"
 set -ogq @cpu_medium_bg_color "#{E:@catppuccin_status_module_text_bg}"
-set -ogq @cpu_high_bg_color "#{E:@thm_red}"
+set -ogq @cpu_high_bg_color "#{@thm_red}"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_yellow}"
 set -ogq "@catppuccin_status_${MODULE_NAME}_text_fg" "#{l:#{cpu_fg_color}}"
 set -ogq "@catppuccin_status_${MODULE_NAME}_text_bg" "#{l:#{cpu_bg_color}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{l:#{cpu_percentage}}"

--- a/status/date_time.conf
+++ b/status/date_time.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="date_time"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰃰 "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_sapphire}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_sapphire}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " %Y-%m-%d %H:%M"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/directory.conf
+++ b/status/directory.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="directory"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_rosewater}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_rosewater}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{b:pane_current_path}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/gitmux.conf
+++ b/status/gitmux.conf
@@ -3,7 +3,7 @@
 
 # Requires https://github.com/arl/gitmux
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊢 "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_teal}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_teal}"
 set -gq "@catppuccin_${MODULE_NAME}_text" ' #(gitmux -cfg $HOME/.gitmux.conf "#{pane_current_path}")'
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/host.conf
+++ b/status/host.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="host"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰒋 "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_mauve}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_mauve}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #H"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/kube.conf
+++ b/status/kube.conf
@@ -4,9 +4,9 @@
 # Requires https://github.com/jonmosco/kube-tmux
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󱃾 "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
-set -ogqF "@catppuccin_kube_context_color" "#{E:@thm_red}"
-set -ogqF "@catppuccin_kube_namespace_color" "#{E:@thm_sky}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_blue}"
+set -ogqF "@catppuccin_kube_context_color" "#{@thm_red}"
+set -ogqF "@catppuccin_kube_namespace_color" "#{@thm_sky}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" \
    " #{l:#[fg=#{@catppuccin_kube_context_color}]#{kubectx_context}#[fg=default]:#[fg=#{@catppuccin_kube_namespace_color}]#{kubectx_namespace}}"
 

--- a/status/load.conf
+++ b/status/load.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="load"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" "󰊚 "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_blue}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_blue}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" "#{l:#(uptime | awk '{split(substr($0, index($0, \"load\")), a, \":\"); print a[2]\}}')"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/pomodoro_plus.conf
+++ b/status/pomodoro_plus.conf
@@ -3,7 +3,7 @@
 %hidden MODULE_NAME="pomodoro_plus"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_peach}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_peach}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{l:#{pomodoro_status}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/ram.conf
+++ b/status/ram.conf
@@ -1,16 +1,16 @@
 # vim:set ft=tmux:
 %hidden MODULE_NAME="ram"
 
-set -ogq @ram_low_fg_color "#{E:@thm_fg}"
-set -ogq @ram_medium_fg_color "#{E:@thm_fg}"
-set -ogq @ram_high_fg_color "#{E:@thm_crust}"
+set -ogq @ram_low_fg_color "#{@thm_fg}"
+set -ogq @ram_medium_fg_color "#{@thm_fg}"
+set -ogq @ram_high_fg_color "#{@thm_crust}"
 
 set -ogq @ram_low_bg_color "#{E:@catppuccin_status_module_text_bg}"
 set -ogq @ram_medium_bg_color "#{E:@catppuccin_status_module_text_bg}"
-set -ogq @ram_high_bg_color "#{E:@thm_red}"
+set -ogq @ram_high_bg_color "#{@thm_red}"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{E:@thm_yellow}"
+set -ogqF "@catppuccin_${MODULE_NAME}_color" "#{@thm_yellow}"
 set -ogq "@catppuccin_status_${MODULE_NAME}_text_fg" "#{l:#{ram_fg_color}}"
 set -ogq "@catppuccin_status_${MODULE_NAME}_text_bg" "#{l:#{ram_bg_color}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #{l:#{ram_percentage}}"

--- a/status/session.conf
+++ b/status/session.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="session"
 
 set -ogq "@catppuccin_${MODULE_NAME}_icon" " "
-set -ogq "@catppuccin_${MODULE_NAME}_color" "#{?client_prefix,#{E:@thm_red},#{E:@thm_green}}"
+set -ogq "@catppuccin_${MODULE_NAME}_color" "#{?client_prefix,#{@thm_red},#{@thm_green}}"
 set -ogq "@catppuccin_${MODULE_NAME}_text" " #S"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/uptime.conf
+++ b/status/uptime.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="uptime"
 
 set -ogq @catppuccin_uptime_icon "󰔟 "
-set -ogqF @catppuccin_uptime_color "#{E:@thm_sapphire}"
+set -ogqF @catppuccin_uptime_color "#{@thm_sapphire}"
 set -ogq @catppuccin_uptime_text " #(uptime | sed 's/^[^,]*up *//; s/, *[[:digit:]]* user.*//; s/ day.*, */d /; s/ hr\\(s*\\).*/h/; s/ min\\(s*\\).*/m/; s/ sec\\(s*\\).*/s/; s/\\([0-9]\\{1,2\\}\\):\\([0-9]\\{1,2\\}\\)/\\1h \\2m/;')"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/user.conf
+++ b/status/user.conf
@@ -2,7 +2,7 @@
 %hidden MODULE_NAME="user"
 
 set -ogq @catppuccin_user_icon " "
-set -ogqF @catppuccin_user_color "#{E:@thm_sky}"
+set -ogqF @catppuccin_user_color "#{@thm_sky}"
 set -ogq @catppuccin_user_text " #(whoami)"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/status/weather.conf
+++ b/status/weather.conf
@@ -4,7 +4,7 @@
 # Requires https://github.com/xamut/tmux-weather.
 
 set -ogq @catppuccin_weather_icon " "
-set -ogqF @catppuccin_weather_color "#{E:@thm_yellow}"
+set -ogqF @catppuccin_weather_color "#{@thm_yellow}"
 set -ogq @catppuccin_weather_text " #{l:#{weather}}"
 
 source -F "#{d:current_file}/../utils/status_module.conf"

--- a/tests/cpu_module.sh
+++ b/tests/cpu_module.sh
@@ -4,8 +4,7 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 # shellcheck disable=SC1091
 source "${script_dir}/helpers.sh"
 
-# Tests that the default options are set correctly
-tmux source "${script_dir}/../catppuccin_options_tmux.conf"
-tmux source "${script_dir}/../catppuccin_tmux.conf"
+# Load via the plugin entrypoint so the render-safe hex escaping is applied.
+tmux run-shell "${script_dir}/../catppuccin.tmux"
 
 print_option E:@catppuccin_status_cpu

--- a/tests/load_module.sh
+++ b/tests/load_module.sh
@@ -4,8 +4,7 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 # shellcheck disable=SC1091
 source "${script_dir}/helpers.sh"
 
-# Tests that the default options are set correctly
-tmux source "${script_dir}/../catppuccin_options_tmux.conf"
-tmux source "${script_dir}/../catppuccin_tmux.conf"
+# Load via the plugin entrypoint so the render-safe hex escaping is applied.
+tmux run-shell "${script_dir}/../catppuccin.tmux"
 
 print_option E:@catppuccin_status_load

--- a/tests/ram_module.sh
+++ b/tests/ram_module.sh
@@ -4,8 +4,7 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 # shellcheck disable=SC1091
 source "${script_dir}/helpers.sh"
 
-# Tests that the default options are set correctly
-tmux source "${script_dir}/../catppuccin_options_tmux.conf"
-tmux source "${script_dir}/../catppuccin_tmux.conf"
+# Load via the plugin entrypoint so the render-safe hex escaping is applied.
+tmux run-shell "${script_dir}/../catppuccin.tmux"
 
 print_option E:@catppuccin_status_ram

--- a/utils/status_module.conf
+++ b/utils/status_module.conf
@@ -14,8 +14,8 @@ set -gqF @_ctp_connect_style \
 #   - fg: @catppuccin_status_[module]_text_fg [default = foreground]
 #   - bg: @catppuccin_status_[module]_text_bg [default = @catppuccin_status_module_text_bg]
 
-set -ogqF "@catppuccin_status_${MODULE_NAME}_icon_fg" "#{E:@thm_crust}"
-set -ogqF "@catppuccin_status_${MODULE_NAME}_text_fg" "#{E:@thm_fg}"
+set -ogqF "@catppuccin_status_${MODULE_NAME}_icon_fg" "#{@thm_crust}"
+set -ogqF "@catppuccin_status_${MODULE_NAME}_text_fg" "#{@thm_fg}"
 
 %if "#{==:#{@catppuccin_status_${MODULE_NAME}_icon_bg},}"
   set -gqF "@catppuccin_status_${MODULE_NAME}_icon_bg" "#{@catppuccin_${MODULE_NAME}_color}"


### PR DESCRIPTION
Closes #596.

## Problem

tmux `next-3.7` (via the run-shell argument feature, tmux/tmux#5121, merged 2026-06-01) added `#1`–`#9` as positional-argument shorthand in `format_expand1`. Expanding a format at **render time** now eats the first digit of any literal `#RRGGBB` whose first hex digit is 1–9 (`#15232d` → `5232d`), producing invalid colors.

Every flavor uses such colors (mocha `#1e1e2e` / `#11111b`, surfaces, …), so **status modules, the window list, and pane borders all render broken** under next-3.7. Released tmux ≤ 3.6 is unaffected.

## Fix

Two changes, one render-safety rule:

1. **Resolve theme colors with `#{@thm_*}` instead of `#{E:@thm_*}`** where the value is a literal hex. The extra `#{E:}` pass re-scans the resolved hex and eats the leading digit at *build* time; a single resolution doesn't. (`@thm_*` always holds a literal hex across every flavor, never a reference.)

2. **Escape `#RRGGBB` → `##RRGGBB`** (in `catppuccin.tmux`) for the formats tmux expands at *render* time — `window-status-format`, `window-status-current-format`, `pane-border-format`, and the `@catppuccin_status_*` module strings. The render unescapes them back to intact `#RRGGBB`. Deferred references and runtime conditionals carry no literal and are untouched. The pass is **idempotent** (unescape-then-escape), so it survives reloads where `-o`-set options aren't rebuilt.

## Tests

- The `cpu` / `load` / `ram` module tests now load through the `catppuccin.tmux` entrypoint, so the escaping pass runs and their `#{E:…}` assertions exercise the render-safe round-trip. Suite passes on tmux `3.4` and `next-3.7`.
- A new **non-blocking** CI job (`continue-on-error`) builds tmux `master` and runs the suite, surfacing upstream breakage early without gating PRs for released tmux.

Manually verified on `next-3.7` with a flavor using `#1`/`#3`/`#8`/`#9`-leading colors: status modules (incl. `session`'s runtime `client_prefix` conditional), window list, and pane borders all render correct colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)