### PR TITLE
fix(#600): command and messages regression after 3.7 update

### DIFF
--- a/catppuccin_tmux.conf
+++ b/catppuccin_tmux.conf
@@ -5,17 +5,20 @@ source -F "#{d:current_file}/themes/catppuccin_#{@catppuccin_flavor}_tmux.conf"
   set -gF status-style "bg=#{@_ctp_status_bg},fg=#{@thm_fg}"
 
   %hidden CTP_MESSAGE_BACKGROUND="#{@thm_overlay_0}"
+  %hidden CTP_MESSAGE_FILL="#{@thm_overlay_0}"
 %elif "#{==:#{@catppuccin_status_background},none}"
   set -g status-style "default"
   set -g @_ctp_status_bg "none"
 
   %hidden CTP_MESSAGE_BACKGROUND="default"
+  %hidden CTP_MESSAGE_FILL="terminal"
 %else
   # Treat @catppuccin_status_background as a format string.
   set -gF status-style "bg=#{E:@catppuccin_status_background},fg=#{@thm_fg}"
   set -gF @_ctp_status_bg "#{E:@catppuccin_status_background}"
 
   %hidden CTP_MESSAGE_BACKGROUND="#{E:@catppuccin_status_background}"
+  %hidden CTP_MESSAGE_FILL="#{E:@catppuccin_status_background}"
 %endif
 
 source -F "#{d:current_file}/status/application.conf"
@@ -36,8 +39,8 @@ source -F "#{d:current_file}/status/user.conf"
 source -F "#{d:current_file}/status/weather.conf"
 
 # messages
-set -gF message-style "fg=#{@thm_teal},bg=$CTP_MESSAGE_BACKGROUND,align=centre"
-set -gF message-command-style "fg=#{@thm_teal},bg=$CTP_MESSAGE_BACKGROUND,align=centre"
+set -gF message-style "fg=#{@thm_teal},bg=$CTP_MESSAGE_BACKGROUND,fill=$CTP_MESSAGE_FILL"
+set -gF message-command-style "fg=#{@thm_teal},bg=$CTP_MESSAGE_BACKGROUND,fill=$CTP_MESSAGE_FILL"
 
 # menu
 %if "#{>=:#{version},3.4}"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/default_options.sh --expected "${script_dir}"/tests/default_options_expected.txt "$@"
+"${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/message_styling.sh --expected "${script_dir}"/tests/message_styling_expected.txt "$@"
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/window_status_styling.sh --expected "${script_dir}"/tests/window_status_styling_expected.txt "$@"
 
 "${script_dir}"/tests/harness.sh --test "${script_dir}"/tests/application_module.sh --expected "${script_dir}"/tests/application_module_expected.txt "$@"

--- a/tests/message_styling.sh
+++ b/tests/message_styling.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+# shellcheck disable=SC1091
+source "${script_dir}/helpers.sh"
+
+print_message_styles() {
+  print_option message-style
+  print_option message-command-style
+}
+
+tmux source "${script_dir}/../catppuccin_options_tmux.conf"
+tmux set -g @catppuccin_status_background "none"
+tmux source "${script_dir}/../catppuccin_tmux.conf"
+print_message_styles
+
+tmux set -g @catppuccin_status_background "red"
+tmux source "${script_dir}/../catppuccin_tmux.conf"
+print_message_styles

--- a/tests/message_styling_expected.txt
+++ b/tests/message_styling_expected.txt
@@ -1,0 +1,4 @@
+message-style fg=#94e2d5,bg=default,fill=terminal
+message-command-style fg=#94e2d5,bg=default,fill=terminal
+message-style fg=#94e2d5,bg=red,fill=red
+message-command-style fg=#94e2d5,bg=red,fill=red


### PR DESCRIPTION
This change fixes #600 

Before:

<img width="2472" height="114" alt="screenshot-20260831-082204" src="https://github.com/user-attachments/assets/6c5af6a0-9c29-472c-ae7c-91971db1a103" />

After:

<img width="2464" height="108" alt="screenshot-20260831-082140" src="https://github.com/user-attachments/assets/2ad0a52b-eecd-4b47-911a-65ea71bbdffe" />